### PR TITLE
[Feat] Navigation Manager, Account Manager 개선, Onbarding 플로우 정의

### DIFF
--- a/Shoak.xcodeproj/project.pbxproj
+++ b/Shoak.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		1E2939802C51E00D00B321DC /* AppleLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E29397F2C51E00D00B321DC /* AppleLoginView.swift */; };
 		1E2939822C51E07E00B321DC /* AppleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2939812C51E07E00B321DC /* AppleUseCase.swift */; };
 		1E2939852C51F2A200B321DC /* AppleSignInButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E2939842C51F2A200B321DC /* AppleSignInButton.swift */; };
+		6FC0A12A2C54C82B004560E3 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1292C54C82B004560E3 /* LoginView.swift */; };
+		6FC0A12C2C54CA29004560E3 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */; };
+		6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12D2C54CB11004560E3 /* AccountManager.swift */; };
 		6FF9B7742C4F896800FC0CB2 /* ShoakApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */; };
 		6FF9B7782C4F896A00FC0CB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */; };
 		6FF9B77B2C4F896A00FC0CB2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B77A2C4F896A00FC0CB2 /* Preview Assets.xcassets */; };
@@ -27,7 +30,7 @@
 		6FF9B7AC2C51322900FC0CB2 /* StartShoakProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7AB2C51322900FC0CB2 /* StartShoakProcess.swift */; };
 		6FF9B7AE2C51340000FC0CB2 /* SendShoakUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7AD2C51340000FC0CB2 /* SendShoakUseCase.swift */; };
 		6FF9B7B12C51F82B00FC0CB2 /* ShoakDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B02C51F82B00FC0CB2 /* ShoakDataManager.swift */; };
-		6FF9B7B32C51F84600FC0CB2 /* NavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B22C51F84600FC0CB2 /* NavigationModel.swift */; };
+		6FF9B7B32C51F84600FC0CB2 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B22C51F84600FC0CB2 /* NavigationManager.swift */; };
 		6FF9B7B52C52211A00FC0CB2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B42C52211A00FC0CB2 /* RootView.swift */; };
 		6FF9B7BD2C52378B00FC0CB2 /* ShoakWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7BC2C52378B00FC0CB2 /* ShoakWatchApp.swift */; };
 		6FF9B7BF2C52378B00FC0CB2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7BE2C52378B00FC0CB2 /* ContentView.swift */; };
@@ -44,7 +47,7 @@
 		6FF9B7D72C5243DC00FC0CB2 /* WatchFriendListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7D62C5243DC00FC0CB2 /* WatchFriendListView.swift */; };
 		6FF9B7DA2C52441700FC0CB2 /* WatchSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7D92C52441700FC0CB2 /* WatchSettingView.swift */; };
 		6FF9B7DB2C5244B400FC0CB2 /* StartShoakProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7AB2C51322900FC0CB2 /* StartShoakProcess.swift */; };
-		6FF9B7DC2C5246A000FC0CB2 /* NavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B22C51F84600FC0CB2 /* NavigationModel.swift */; };
+		6FF9B7DC2C5246A000FC0CB2 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B22C51F84600FC0CB2 /* NavigationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +79,9 @@
 		1E29397F2C51E00D00B321DC /* AppleLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginView.swift; sourceTree = "<group>"; };
 		1E2939812C51E07E00B321DC /* AppleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleUseCase.swift; sourceTree = "<group>"; };
 		1E2939842C51F2A200B321DC /* AppleSignInButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInButton.swift; sourceTree = "<group>"; };
+		6FC0A1292C54C82B004560E3 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		6FC0A12D2C54CB11004560E3 /* AccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
 		6FF9B7702C4F896800FC0CB2 /* Shoak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shoak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakApp.swift; sourceTree = "<group>"; };
 		6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -94,7 +100,7 @@
 		6FF9B7AB2C51322900FC0CB2 /* StartShoakProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartShoakProcess.swift; sourceTree = "<group>"; };
 		6FF9B7AD2C51340000FC0CB2 /* SendShoakUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendShoakUseCase.swift; sourceTree = "<group>"; };
 		6FF9B7B02C51F82B00FC0CB2 /* ShoakDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakDataManager.swift; sourceTree = "<group>"; };
-		6FF9B7B22C51F84600FC0CB2 /* NavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationModel.swift; sourceTree = "<group>"; };
+		6FF9B7B22C51F84600FC0CB2 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		6FF9B7B42C52211A00FC0CB2 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		6FF9B7BA2C52378B00FC0CB2 /* ShoakWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ShoakWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FF9B7BC2C52378B00FC0CB2 /* ShoakWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakWatchApp.swift; sourceTree = "<group>"; };
@@ -135,6 +141,7 @@
 			isa = PBXGroup;
 			children = (
 				6FF9B7912C50E6A000FC0CB2 /* FriendListView.swift */,
+				6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -216,7 +223,8 @@
 			children = (
 				6FF9B7AF2C51400400FC0CB2 /* Intents */,
 				6FF9B7B02C51F82B00FC0CB2 /* ShoakDataManager.swift */,
-				6FF9B7B22C51F84600FC0CB2 /* NavigationModel.swift */,
+				6FF9B7B22C51F84600FC0CB2 /* NavigationManager.swift */,
+				6FC0A12D2C54CB11004560E3 /* AccountManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -302,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				6FF9B7952C50E6B300FC0CB2 /* SettingView.swift */,
+				6FC0A1292C54C82B004560E3 /* LoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -458,6 +467,7 @@
 				6FF9B79E2C50E6DE00FC0CB2 /* AccountUseCase.swift in Sources */,
 				6FF9B7AA2C512C9F00FC0CB2 /* Errors.swift in Sources */,
 				6FF9B7AE2C51340000FC0CB2 /* SendShoakUseCase.swift in Sources */,
+				6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */,
 				1E2939822C51E07E00B321DC /* AppleUseCase.swift in Sources */,
 				1E2939852C51F2A200B321DC /* AppleSignInButton.swift in Sources */,
 				1E2939802C51E00D00B321DC /* AppleLoginView.swift in Sources */,
@@ -467,14 +477,16 @@
 				6FF9B7B52C52211A00FC0CB2 /* RootView.swift in Sources */,
 				6FF9B79C2C50E6D700FC0CB2 /* SampleUseCase2.swift in Sources */,
 				6FF9B7742C4F896800FC0CB2 /* ShoakApp.swift in Sources */,
-				6FF9B7B32C51F84600FC0CB2 /* NavigationModel.swift in Sources */,
+				6FF9B7B32C51F84600FC0CB2 /* NavigationManager.swift in Sources */,
 				6FF9B7AC2C51322900FC0CB2 /* StartShoakProcess.swift in Sources */,
 				6FF9B79A2C50E6CB00FC0CB2 /* UserUseCase.swift in Sources */,
+				6FC0A12A2C54C82B004560E3 /* LoginView.swift in Sources */,
 				6FF9B7B12C51F82B00FC0CB2 /* ShoakDataManager.swift in Sources */,
 				6FF9B7942C50E6A700FC0CB2 /* SwiftUIView2.swift in Sources */,
 				6FF9B7A82C50ECD200FC0CB2 /* CaseIterable+.swift in Sources */,
 				6FF9B7922C50E6A000FC0CB2 /* FriendListView.swift in Sources */,
 				6FF9B7962C50E6B300FC0CB2 /* SettingView.swift in Sources */,
+				6FC0A12C2C54CA29004560E3 /* OnboardingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -494,7 +506,7 @@
 				6FF9B7D72C5243DC00FC0CB2 /* WatchFriendListView.swift in Sources */,
 				6FF9B7DA2C52441700FC0CB2 /* WatchSettingView.swift in Sources */,
 				6FF9B7BD2C52378B00FC0CB2 /* ShoakWatchApp.swift in Sources */,
-				6FF9B7DC2C5246A000FC0CB2 /* NavigationModel.swift in Sources */,
+				6FF9B7DC2C5246A000FC0CB2 /* NavigationManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Shoak/Actors/CommonActor/UseCases/AccountUseCase.swift
+++ b/Shoak/Actors/CommonActor/UseCases/AccountUseCase.swift
@@ -1,7 +1,7 @@
 
 final class AccountUseCase {
     func isLoggedIn() -> Bool {
-        return true
+        return false
     }
 
     func getMyMemberID() -> TMMemberID? {

--- a/Shoak/Actors/CommonActor/View/LoginView.swift
+++ b/Shoak/Actors/CommonActor/View/LoginView.swift
@@ -1,0 +1,33 @@
+//
+//  LoginView.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    @Environment(AccountManager.self) private var accountManager
+    @Environment(NavigationManager.self) private var navigationManager
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Button("(상황 가정 : 처음 로그인 시)\n온보딩 띄우는 로그인") {
+                navigationManager.setView(to: .onboarding)
+            }
+
+            Button("(상황 가정 : 재로그인 시)\n바로 친구창으로 가는 로그인") {
+                navigationManager.setView(to: .friendList)
+            }
+
+            AppleLoginView(useCase: AppleUseCase())
+                .frame(maxHeight: 200)
+        }
+        .onAppear {
+            if accountManager.isLoggedIn {
+                navigationManager.setView(to: .friendList)
+            }
+        }
+    }
+}

--- a/Shoak/Actors/CommonActor/View/SettingView.swift
+++ b/Shoak/Actors/CommonActor/View/SettingView.swift
@@ -2,12 +2,12 @@
 import SwiftUI
 
 struct SettingView: View {
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
     var body: some View {
         Text("Setting")
 
         Button("Go to Friend List") {
-            navigationModel.setView(to: .friendList)
+            navigationManager.setView(to: .friendList)
         }
     }
 }

--- a/Shoak/Actors/ShoakActor/View/FriendListView.swift
+++ b/Shoak/Actors/ShoakActor/View/FriendListView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct FriendListView: View {
     @Environment(ShoakDataManager.self) private var shoakDataManager
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
 
     var body: some View {
         VStack {
@@ -12,7 +12,11 @@ struct FriendListView: View {
             }
 
             Button("Go to Setting") {
-                navigationModel.setView(to: .settings)
+                navigationManager.setView(to: .settings)
+            }
+
+            Button("Go to Onboarding") {
+                navigationManager.setView(to: .onboarding)
             }
         }
     }

--- a/Shoak/Actors/ShoakActor/View/OnboardingView.swift
+++ b/Shoak/Actors/ShoakActor/View/OnboardingView.swift
@@ -1,0 +1,103 @@
+//
+//  OnboardingView.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    @Environment(NavigationManager.self) private var navigationManager
+    @State private var currentPage: ContinuousView = .start
+
+    var body: some View {
+        VStack(spacing: 32) {
+            currentPage
+
+            Button(currentActionLabel) {
+                Task {
+                    await currentAction()
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Computed Properties for currentPage
+extension OnboardingView {
+    var currentActionLabel: String {
+        switch currentPage {
+        case .finish:
+            "친구들 보러 가기"
+        default:
+            "다음"
+        }
+    }
+
+    var currentAction: () async -> Void {
+        switch currentPage {
+        case .finish:
+            { await navigationManager.setView(to: .friendList) }
+        default:
+            { currentPage = currentPage.next() }
+        }
+    }
+}
+
+// MARK: - Define Continuous View
+extension OnboardingView {
+    enum ContinuousView: View, CaseIterable {
+        case start
+        case addShortcut
+        case configureAccessibility
+        case addFriends
+        case finish
+
+        var body: some View {
+            switch self {
+            case .start:
+                StartView()
+            case .addShortcut:
+                AddShortcutView()
+            case .configureAccessibility:
+                ConfigureAccessibilityView()
+            case .addFriends:
+                AddFriendsView()
+            case .finish:
+                FinishView()
+            }
+        }
+    }
+}
+
+// MARK: - Views for Onboarding
+private struct StartView: View {
+    var body: some View {
+        Text("Onboarding Start!!")
+    }
+}
+
+private struct AddShortcutView: View {
+    var body: some View {
+        Text("Add Shortcut")
+    }
+}
+
+private struct ConfigureAccessibilityView: View {
+    var body: some View {
+        Text("Configure Accessibility")
+    }
+}
+
+private struct AddFriendsView: View {
+    var body: some View {
+        Text("Add Friend")
+    }
+}
+
+private struct FinishView: View {
+    var body: some View {
+        Text("Onboarding Finish!")
+    }
+}

--- a/Shoak/Common/AccountManager.swift
+++ b/Shoak/Common/AccountManager.swift
@@ -1,0 +1,26 @@
+//
+//  AccountManager.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+
+@Observable
+class AccountManager: @unchecked Sendable {
+    static let shared = AccountManager()
+
+    @ObservationIgnored private let accountUseCase: AccountUseCase
+
+    private init() {
+        self.accountUseCase = AccountUseCase()
+    }
+}
+
+// MARK: - Computed Properties
+extension AccountManager {
+    var isLoggedIn: Bool {
+        accountUseCase.isLoggedIn()
+    }
+}

--- a/Shoak/Common/Intents/StartShoakProcess.swift
+++ b/Shoak/Common/Intents/StartShoakProcess.swift
@@ -15,12 +15,12 @@ struct StartShoakProcess: AppIntent {
     static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     func perform() async throws -> some IntentResult {
-        await navigationModel.setView(to: .friendList)
+        await navigationManager.setView(to: .friendList)
         return .result()
     }
 
     @Dependency
-    private var navigationModel: NavigationModel
+    private var navigationManager: NavigationManager
 
     @Dependency
     private var dataManager: ShoakDataManager

--- a/Shoak/Common/NavigationManager.swift
+++ b/Shoak/Common/NavigationManager.swift
@@ -1,5 +1,5 @@
 //
-//  NavigationModel.swift
+//  NavigationManager.swift
 //  Shoak
 //
 //  Created by 정종인 on 7/25/24.
@@ -9,30 +9,38 @@ import SwiftUI
 
 @MainActor
 @Observable
-class NavigationModel {
+class NavigationManager {
     var view: SwitchableView
 
     init() {
-        self.view = .friendList
+        self.view = .login
     }
 
     public func nextPhase() {
         self.view = self.view.next()
     }
 
-    public func setView(to view: SwitchableView) {
-        self.view = view
+    public func setView(to view: SwitchableView, with animation: Animation = .default) {
+        withAnimation(animation) {
+            self.view = view
+        }
     }
 }
 
-extension NavigationModel {
+extension NavigationManager {
     enum SwitchableView: View, CaseIterable {
+        case login
+        case onboarding
         case friendList
         case settings
 
         var body: some View {
 #if os(iOS)
             switch self {
+            case .login:
+                LoginView()
+            case .onboarding:
+                OnboardingView()
             case .friendList:
                 FriendListView()
             case .settings:
@@ -44,6 +52,8 @@ extension NavigationModel {
                 WatchFriendListView()
             case .settings:
                 WatchSettingView()
+            default:
+                EmptyView()
             }
 #endif
         }

--- a/Shoak/Common/ShoakDataManager.swift
+++ b/Shoak/Common/ShoakDataManager.swift
@@ -13,10 +13,7 @@ class ShoakDataManager: @unchecked Sendable {
 
     let friends: [TMProfileVO]
 
-    private let accountUseCase: AccountUseCase
-
     private init() {
         self.friends = .mockData
-        self.accountUseCase = AccountUseCase()
     }
 }

--- a/Shoak/RootView.swift
+++ b/Shoak/RootView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct RootView: View {
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
     var body: some View {
-        navigationModel.view
+        navigationManager.view
     }
 }
 

--- a/Shoak/ShoakApp.swift
+++ b/Shoak/ShoakApp.swift
@@ -11,26 +11,30 @@ import AppIntents
 @main
 struct ShoakApp: App {
     private var shoakDataManager: ShoakDataManager
-    private let navigationModel: NavigationModel
+    private var accountManager: AccountManager
+    private let navigationManager: NavigationManager
 
     init() {
         let shoakDataManager = ShoakDataManager.shared
         self.shoakDataManager = shoakDataManager
 
-        let navigationModel = NavigationModel()
-        self.navigationModel = navigationModel
+        let accountManager = AccountManager.shared
+        self.accountManager = accountManager
+
+        let navigationManager = NavigationManager()
+        self.navigationManager = navigationManager
 
         AppDependencyManager.shared.add(dependency: shoakDataManager)
-        AppDependencyManager.shared.add(dependency: navigationModel)
+        AppDependencyManager.shared.add(dependency: accountManager)
+        AppDependencyManager.shared.add(dependency: navigationManager)
     }
 
     var body: some Scene {
         WindowGroup {
-            //RootView()
-                //.environment(shoakDataManager)
-                //.environment(navigationModel)
-            //MyPageView(useCase: ShoakUseCase())
-            AppleLoginView(useCase: AppleUseCase())
+            RootView()
+                .environment(shoakDataManager)
+                .environment(accountManager)
+                .environment(navigationManager)
         }
     }
 }

--- a/ShoakWatch Watch App/ShoakWatchApp.swift
+++ b/ShoakWatch Watch App/ShoakWatchApp.swift
@@ -11,24 +11,24 @@ import AppIntents
 @main
 struct ShoakWatch_Watch_AppApp: App {
     private var shoakDataManager: ShoakDataManager
-    private let navigationModel: NavigationModel
+    private let navigationManager: NavigationManager
 
     init() {
         let shoakDataManager = ShoakDataManager.shared
         self.shoakDataManager = shoakDataManager
 
-        let navigationModel = NavigationModel()
-        self.navigationModel = navigationModel
+        let navigationManager = NavigationManager()
+        self.navigationManager = navigationManager
 
         AppDependencyManager.shared.add(dependency: shoakDataManager)
-        AppDependencyManager.shared.add(dependency: navigationModel)
+        AppDependencyManager.shared.add(dependency: navigationManager)
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(shoakDataManager)
-                .environment(navigationModel)
+                .environment(navigationManager)
         }
     }
 }

--- a/ShoakWatch Watch App/View/ContentView.swift
+++ b/ShoakWatch Watch App/View/ContentView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct ContentView: View {
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
     var body: some View {
-        navigationModel.view
+        navigationManager.view
     }
 }
 

--- a/ShoakWatch Watch App/View/WatchFriendListView.swift
+++ b/ShoakWatch Watch App/View/WatchFriendListView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct WatchFriendListView: View {
     @Environment(ShoakDataManager.self) private var shoakDataManager
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
 
     var body: some View {
         VStack {
@@ -18,7 +18,7 @@ struct WatchFriendListView: View {
             }
 
             Button("Go to Setting") {
-                navigationModel.setView(to: .settings)
+                navigationManager.setView(to: .settings)
             }
         }
     }

--- a/ShoakWatch Watch App/View/WatchSettingView.swift
+++ b/ShoakWatch Watch App/View/WatchSettingView.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct WatchSettingView: View {
-    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(NavigationManager.self) private var navigationManager
     var body: some View {
         Text("Setting")
 
         Button("Go to Friend List") {
-            navigationModel.setView(to: .friendList)
+            navigationManager.setView(to: .friendList)
         }
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Navigation이 조금 더 독립적으로 동작할 수 있도록 개선했습니다.
AccountManager으로 계정 관리할 수 있도록 했습니다.
Onboarding 플로우를 정의했으며, 화면 전환이 어떻게 될 예정인지도 정의했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #13 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
Navigation은 기존에 사용했던 시스템과 많은 차이가 있습니다. 앱 특성상 커스텀 화면이 많을 것 같아서 이렇게 정의하였습니다.
특정 화면에서 다른 화면으로 넘어갈 때가 많고, back button등이 기본 컴포넌트와 다를 것 같아서 NavigationManager를 정의했습니다.
* NavigationManager의 SwitchableView를 통해 각 케이스마다 어떤 뷰를 표현하는지 명시합니다.
* RootView에서 NavigationManager의 SwitchableView를 띄웁니다.
* 이제 어디서든 .environment로 주입된 NavigationManager의 .setView 함수를 통해 뷰를 전환할 수 있습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/60dca8a6-3ad5-466b-a087-c11f6994b84d


