### PR TITLE
[feat] 유저 유스케이스 서버 연결 및 테스트 코드 추가

### DIFF
--- a/Shoak.xcodeproj/project.pbxproj
+++ b/Shoak.xcodeproj/project.pbxproj
@@ -214,9 +214,9 @@
 			children = (
 				6FC0A1402C551B20004560E3 /* URLProvider.swift */,
 				6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */,
+				6FC0A1502C5524DE004560E3 /* NetworkError.swift */,
 				6FC0A1492C55207C004560E3 /* Repository */,
 				6FC0A1352C551A3A004560E3 /* API */,
-				6FC0A1502C5524DE004560E3 /* NetworkError.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -724,6 +724,149 @@
 			};
 			name = Release;
 		};
+		6FC0A16C2C5544BE004560E3 /* TEST */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "TEST $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = TEST;
+		};
+		6FC0A16D2C5544BE004560E3 /* TEST */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Shoak/Shoak.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Shoak/Preview Content\"";
+				DEVELOPMENT_TEAM = R62RZ89ZRU;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Shoak/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = team.mosuchalamet.Shoak;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = TEST;
+		};
+		6FC0A16E2C5544BE004560E3 /* TEST */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"ShoakWatch Watch App/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShoakWatch-Watch-App-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = ShoakWatch;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = team.mosuchalamet.Shoak;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = team.mosuchalamet.Shoak.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.5;
+			};
+			name = TEST;
+		};
+		6FC0A16F2C5544BE004560E3 /* TEST */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = team.mosuchalamet.ShoakTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Shoak.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Shoak";
+			};
+			name = TEST;
+		};
 		6FF9B77C2C4F896A00FC0CB2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -976,6 +1119,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6FC0A1672C552E3F004560E3 /* Debug */,
+				6FC0A16F2C5544BE004560E3 /* TEST */,
 				6FC0A1682C552E3F004560E3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -985,6 +1129,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6FF9B77C2C4F896A00FC0CB2 /* Debug */,
+				6FC0A16C2C5544BE004560E3 /* TEST */,
 				6FF9B77D2C4F896A00FC0CB2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -994,6 +1139,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6FF9B77F2C4F896A00FC0CB2 /* Debug */,
+				6FC0A16D2C5544BE004560E3 /* TEST */,
 				6FF9B7802C4F896A00FC0CB2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -1003,6 +1149,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6FF9B7C92C52378C00FC0CB2 /* Debug */,
+				6FC0A16E2C5544BE004560E3 /* TEST */,
 				6FF9B7CA2C52378C00FC0CB2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Shoak.xcodeproj/project.pbxproj
+++ b/Shoak.xcodeproj/project.pbxproj
@@ -13,6 +13,26 @@
 		6FC0A12A2C54C82B004560E3 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1292C54C82B004560E3 /* LoginView.swift */; };
 		6FC0A12C2C54CA29004560E3 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */; };
 		6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12D2C54CB11004560E3 /* AccountManager.swift */; };
+		6FC0A1312C551997004560E3 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 6FC0A1302C551997004560E3 /* Moya */; };
+		6FC0A1342C5519C8004560E3 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 6FC0A1332C5519C8004560E3 /* Moya */; };
+		6FC0A1372C551A70004560E3 /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1362C551A70004560E3 /* UserAPI.swift */; };
+		6FC0A1382C551A70004560E3 /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1362C551A70004560E3 /* UserAPI.swift */; };
+		6FC0A1412C551B20004560E3 /* URLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1402C551B20004560E3 /* URLProvider.swift */; };
+		6FC0A1422C551B20004560E3 /* URLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1402C551B20004560E3 /* URLProvider.swift */; };
+		6FC0A1472C551C7D004560E3 /* Secret.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6FC0A1462C551C7D004560E3 /* Secret.plist */; };
+		6FC0A1482C551C7D004560E3 /* Secret.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6FC0A1462C551C7D004560E3 /* Secret.plist */; };
+		6FC0A14B2C5520BA004560E3 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A14A2C5520BA004560E3 /* UserRepository.swift */; };
+		6FC0A14C2C5520BA004560E3 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A14A2C5520BA004560E3 /* UserRepository.swift */; };
+		6FC0A14E2C5523FF004560E3 /* DefaultAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */; };
+		6FC0A14F2C5523FF004560E3 /* DefaultAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */; };
+		6FC0A1512C5524DE004560E3 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1502C5524DE004560E3 /* NetworkError.swift */; };
+		6FC0A1522C5524DE004560E3 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1502C5524DE004560E3 /* NetworkError.swift */; };
+		6FC0A1542C5526EE004560E3 /* MoyaProvider+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1532C5526EE004560E3 /* MoyaProvider+.swift */; };
+		6FC0A1552C5526EE004560E3 /* MoyaProvider+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1532C5526EE004560E3 /* MoyaProvider+.swift */; };
+		6FC0A1572C552BAE004560E3 /* TargetType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1562C552BAE004560E3 /* TargetType+.swift */; };
+		6FC0A1582C552BAE004560E3 /* TargetType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1562C552BAE004560E3 /* TargetType+.swift */; };
+		6FC0A1592C552D86004560E3 /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7992C50E6CB00FC0CB2 /* UserUseCase.swift */; };
+		6FC0A16A2C552FAC004560E3 /* UserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1692C552FAC004560E3 /* UserUseCaseTests.swift */; };
 		6FF9B7742C4F896800FC0CB2 /* ShoakApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */; };
 		6FF9B7782C4F896A00FC0CB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */; };
 		6FF9B77B2C4F896A00FC0CB2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B77A2C4F896A00FC0CB2 /* Preview Assets.xcassets */; };
@@ -51,6 +71,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6FC0A1642C552E3F004560E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6FF9B7682C4F896800FC0CB2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6FF9B76F2C4F896800FC0CB2;
+			remoteInfo = Shoak;
+		};
 		6FF9B7C52C52378C00FC0CB2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6FF9B7682C4F896800FC0CB2 /* Project object */;
@@ -82,6 +109,18 @@
 		6FC0A1292C54C82B004560E3 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		6FC0A12D2C54CB11004560E3 /* AccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
+		6FC0A1362C551A70004560E3 /* UserAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
+		6FC0A1402C551B20004560E3 /* URLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProvider.swift; sourceTree = "<group>"; };
+		6FC0A1462C551C7D004560E3 /* Secret.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Secret.plist; sourceTree = "<group>"; };
+		6FC0A14A2C5520BA004560E3 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
+		6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAPIClient.swift; sourceTree = "<group>"; };
+		6FC0A1502C5524DE004560E3 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		6FC0A1532C5526EE004560E3 /* MoyaProvider+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+.swift"; sourceTree = "<group>"; };
+		6FC0A1562C552BAE004560E3 /* TargetType+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetType+.swift"; sourceTree = "<group>"; };
+		6FC0A15A2C552DE4004560E3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		6FC0A15B2C552DF6004560E3 /* ShoakWatch-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "ShoakWatch-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
+		6FC0A1602C552E3F004560E3 /* ShoakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShoakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FC0A1692C552FAC004560E3 /* UserUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUseCaseTests.swift; sourceTree = "<group>"; };
 		6FF9B7702C4F896800FC0CB2 /* Shoak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shoak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakApp.swift; sourceTree = "<group>"; };
 		6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -112,10 +151,18 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		6FC0A15D2C552E3F004560E3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FF9B76D2C4F896800FC0CB2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC0A1312C551997004560E3 /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,6 +170,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC0A1342C5519C8004560E3 /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,12 +194,58 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		6FC0A1322C5519C8004560E3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6FC0A1352C551A3A004560E3 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				6FC0A1362C551A70004560E3 /* UserAPI.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		6FC0A13F2C551AE5004560E3 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				6FC0A1402C551B20004560E3 /* URLProvider.swift */,
+				6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */,
+				6FC0A1492C55207C004560E3 /* Repository */,
+				6FC0A1352C551A3A004560E3 /* API */,
+				6FC0A1502C5524DE004560E3 /* NetworkError.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		6FC0A1492C55207C004560E3 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				6FC0A14A2C5520BA004560E3 /* UserRepository.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		6FC0A1612C552E3F004560E3 /* ShoakTests */ = {
+			isa = PBXGroup;
+			children = (
+				6FC0A1692C552FAC004560E3 /* UserUseCaseTests.swift */,
+			);
+			path = ShoakTests;
+			sourceTree = "<group>";
+		};
 		6FF9B7672C4F896800FC0CB2 = {
 			isa = PBXGroup;
 			children = (
+				6FC0A1462C551C7D004560E3 /* Secret.plist */,
 				6FF9B7722C4F896800FC0CB2 /* Shoak */,
 				6FF9B7BB2C52378B00FC0CB2 /* ShoakWatch Watch App */,
+				6FC0A1612C552E3F004560E3 /* ShoakTests */,
 				6FF9B7712C4F896800FC0CB2 /* Products */,
+				6FC0A1322C5519C8004560E3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -160,6 +254,7 @@
 			children = (
 				6FF9B7702C4F896800FC0CB2 /* Shoak.app */,
 				6FF9B7BA2C52378B00FC0CB2 /* ShoakWatch Watch App.app */,
+				6FC0A1602C552E3F004560E3 /* ShoakTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -167,6 +262,8 @@
 		6FF9B7722C4F896800FC0CB2 /* Shoak */ = {
 			isa = PBXGroup;
 			children = (
+				6FC0A15A2C552DE4004560E3 /* Info.plist */,
+				6FC0A13F2C551AE5004560E3 /* Network */,
 				1E29397E2C51DF1900B321DC /* Shoak.entitlements */,
 				6FF9B7812C50E5EB00FC0CB2 /* Actors */,
 				6FF9B7822C50E5F500FC0CB2 /* Utility */,
@@ -203,6 +300,8 @@
 			isa = PBXGroup;
 			children = (
 				6FF9B7A72C50ECD200FC0CB2 /* CaseIterable+.swift */,
+				6FC0A1532C5526EE004560E3 /* MoyaProvider+.swift */,
+				6FC0A1562C552BAE004560E3 /* TargetType+.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -335,6 +434,7 @@
 		6FF9B7BB2C52378B00FC0CB2 /* ShoakWatch Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				6FC0A15B2C552DF6004560E3 /* ShoakWatch-Watch-App-Info.plist */,
 				6FF9B7D82C52440200FC0CB2 /* View */,
 				6FF9B7BC2C52378B00FC0CB2 /* ShoakWatchApp.swift */,
 				6FF9B7C02C52378C00FC0CB2 /* Assets.xcassets */,
@@ -364,6 +464,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		6FC0A15F2C552E3F004560E3 /* ShoakTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6FC0A1662C552E3F004560E3 /* Build configuration list for PBXNativeTarget "ShoakTests" */;
+			buildPhases = (
+				6FC0A15C2C552E3F004560E3 /* Sources */,
+				6FC0A15D2C552E3F004560E3 /* Frameworks */,
+				6FC0A15E2C552E3F004560E3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6FC0A1652C552E3F004560E3 /* PBXTargetDependency */,
+			);
+			name = ShoakTests;
+			productName = ShoakTests;
+			productReference = 6FC0A1602C552E3F004560E3 /* ShoakTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6FF9B76F2C4F896800FC0CB2 /* Shoak */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6FF9B77E2C4F896A00FC0CB2 /* Build configuration list for PBXNativeTarget "Shoak" */;
@@ -379,6 +497,9 @@
 				6FF9B7C62C52378C00FC0CB2 /* PBXTargetDependency */,
 			);
 			name = Shoak;
+			packageProductDependencies = (
+				6FC0A1302C551997004560E3 /* Moya */,
+			);
 			productName = Shoak;
 			productReference = 6FF9B7702C4F896800FC0CB2 /* Shoak.app */;
 			productType = "com.apple.product-type.application";
@@ -396,6 +517,9 @@
 			dependencies = (
 			);
 			name = "ShoakWatch Watch App";
+			packageProductDependencies = (
+				6FC0A1332C5519C8004560E3 /* Moya */,
+			);
 			productName = "ShoakWatch Watch App";
 			productReference = 6FF9B7BA2C52378B00FC0CB2 /* ShoakWatch Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -410,6 +534,10 @@
 				LastSwiftUpdateCheck = 1540;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
+					6FC0A15F2C552E3F004560E3 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 6FF9B76F2C4F896800FC0CB2;
+					};
 					6FF9B76F2C4F896800FC0CB2 = {
 						CreatedOnToolsVersion = 15.4;
 					};
@@ -428,21 +556,33 @@
 				ko,
 			);
 			mainGroup = 6FF9B7672C4F896800FC0CB2;
+			packageReferences = (
+				6FC0A12F2C551997004560E3 /* XCRemoteSwiftPackageReference "Moya" */,
+			);
 			productRefGroup = 6FF9B7712C4F896800FC0CB2 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				6FF9B76F2C4F896800FC0CB2 /* Shoak */,
 				6FF9B7B92C52378B00FC0CB2 /* ShoakWatch Watch App */,
+				6FC0A15F2C552E3F004560E3 /* ShoakTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		6FC0A15E2C552E3F004560E3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FF9B76E2C4F896800FC0CB2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC0A1472C551C7D004560E3 /* Secret.plist in Resources */,
 				6FF9B77B2C4F896A00FC0CB2 /* Preview Assets.xcassets in Resources */,
 				6FF9B7782C4F896A00FC0CB2 /* Assets.xcassets in Resources */,
 			);
@@ -452,6 +592,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC0A1482C551C7D004560E3 /* Secret.plist in Resources */,
 				6FF9B7C42C52378C00FC0CB2 /* Preview Assets.xcassets in Resources */,
 				6FF9B7C12C52378C00FC0CB2 /* Assets.xcassets in Resources */,
 			);
@@ -460,12 +601,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		6FC0A15C2C552E3F004560E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6FC0A16A2C552FAC004560E3 /* UserUseCaseTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6FF9B76C2C4F896800FC0CB2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FC0A14B2C5520BA004560E3 /* UserRepository.swift in Sources */,
+				6FC0A1512C5524DE004560E3 /* NetworkError.swift in Sources */,
 				6FF9B79E2C50E6DE00FC0CB2 /* AccountUseCase.swift in Sources */,
+				6FC0A1542C5526EE004560E3 /* MoyaProvider+.swift in Sources */,
+				6FC0A1572C552BAE004560E3 /* TargetType+.swift in Sources */,
 				6FF9B7AA2C512C9F00FC0CB2 /* Errors.swift in Sources */,
+				6FC0A1412C551B20004560E3 /* URLProvider.swift in Sources */,
 				6FF9B7AE2C51340000FC0CB2 /* SendShoakUseCase.swift in Sources */,
 				6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */,
 				1E2939822C51E07E00B321DC /* AppleUseCase.swift in Sources */,
@@ -481,12 +635,14 @@
 				6FF9B7AC2C51322900FC0CB2 /* StartShoakProcess.swift in Sources */,
 				6FF9B79A2C50E6CB00FC0CB2 /* UserUseCase.swift in Sources */,
 				6FC0A12A2C54C82B004560E3 /* LoginView.swift in Sources */,
+				6FC0A1372C551A70004560E3 /* UserAPI.swift in Sources */,
 				6FF9B7B12C51F82B00FC0CB2 /* ShoakDataManager.swift in Sources */,
 				6FF9B7942C50E6A700FC0CB2 /* SwiftUIView2.swift in Sources */,
 				6FF9B7A82C50ECD200FC0CB2 /* CaseIterable+.swift in Sources */,
 				6FF9B7922C50E6A000FC0CB2 /* FriendListView.swift in Sources */,
 				6FF9B7962C50E6B300FC0CB2 /* SettingView.swift in Sources */,
 				6FC0A12C2C54CA29004560E3 /* OnboardingView.swift in Sources */,
+				6FC0A14E2C5523FF004560E3 /* DefaultAPIClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,9 +651,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6FF9B7D02C52399E00FC0CB2 /* TMProfileDTO.swift in Sources */,
+				6FC0A14F2C5523FF004560E3 /* DefaultAPIClient.swift in Sources */,
 				6FF9B7CE2C52390200FC0CB2 /* TMProfileVO.swift in Sources */,
+				6FC0A1422C551B20004560E3 /* URLProvider.swift in Sources */,
+				6FC0A1582C552BAE004560E3 /* TargetType+.swift in Sources */,
 				6FF9B7CF2C52399500FC0CB2 /* TMMemberID.swift in Sources */,
 				6FF9B7D52C5243C700FC0CB2 /* CaseIterable+.swift in Sources */,
+				6FC0A1552C5526EE004560E3 /* MoyaProvider+.swift in Sources */,
+				6FC0A1592C552D86004560E3 /* UserUseCase.swift in Sources */,
 				6FF9B7CC2C52380200FC0CB2 /* ShoakDataManager.swift in Sources */,
 				6FF9B7D12C5239A400FC0CB2 /* Errors.swift in Sources */,
 				6FF9B7D22C5239B300FC0CB2 /* AccountUseCase.swift in Sources */,
@@ -507,12 +668,20 @@
 				6FF9B7DA2C52441700FC0CB2 /* WatchSettingView.swift in Sources */,
 				6FF9B7BD2C52378B00FC0CB2 /* ShoakWatchApp.swift in Sources */,
 				6FF9B7DC2C5246A000FC0CB2 /* NavigationManager.swift in Sources */,
+				6FC0A1522C5524DE004560E3 /* NetworkError.swift in Sources */,
+				6FC0A14C2C5520BA004560E3 /* UserRepository.swift in Sources */,
+				6FC0A1382C551A70004560E3 /* UserAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		6FC0A1652C552E3F004560E3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6FF9B76F2C4F896800FC0CB2 /* Shoak */;
+			targetProxy = 6FC0A1642C552E3F004560E3 /* PBXContainerItemProxy */;
+		};
 		6FF9B7C62C52378C00FC0CB2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 6FF9B7B92C52378B00FC0CB2 /* ShoakWatch Watch App */;
@@ -521,6 +690,40 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		6FC0A1672C552E3F004560E3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = team.mosuchalamet.ShoakTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Shoak.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Shoak";
+			};
+			name = Debug;
+		};
+		6FC0A1682C552E3F004560E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = team.mosuchalamet.ShoakTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Shoak.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Shoak";
+			};
+			name = Release;
+		};
 		6FF9B77C2C4F896A00FC0CB2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -653,6 +856,7 @@
 				DEVELOPMENT_TEAM = R62RZ89ZRU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Shoak/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -684,6 +888,7 @@
 				DEVELOPMENT_TEAM = R62RZ89ZRU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Shoak/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -713,6 +918,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShoakWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = ShoakWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = team.mosuchalamet.Shoak;
@@ -743,6 +949,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "ShoakWatch-Watch-App-Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = ShoakWatch;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = team.mosuchalamet.Shoak;
@@ -765,6 +972,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6FC0A1662C552E3F004560E3 /* Build configuration list for PBXNativeTarget "ShoakTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6FC0A1672C552E3F004560E3 /* Debug */,
+				6FC0A1682C552E3F004560E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6FF9B76B2C4F896800FC0CB2 /* Build configuration list for PBXProject "Shoak" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -793,6 +1009,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6FC0A12F2C551997004560E3 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 15.0.3;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6FC0A1302C551997004560E3 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6FC0A12F2C551997004560E3 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+		6FC0A1332C5519C8004560E3 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6FC0A12F2C551997004560E3 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6FF9B7682C4F896800FC0CB2 /* Project object */;
 }

--- a/Shoak.xcodeproj/project.pbxproj
+++ b/Shoak.xcodeproj/project.pbxproj
@@ -33,6 +33,12 @@
 		6FC0A1582C552BAE004560E3 /* TargetType+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1562C552BAE004560E3 /* TargetType+.swift */; };
 		6FC0A1592C552D86004560E3 /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7992C50E6CB00FC0CB2 /* UserUseCase.swift */; };
 		6FC0A16A2C552FAC004560E3 /* UserUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1692C552FAC004560E3 /* UserUseCaseTests.swift */; };
+		6FC0A1712C554B40004560E3 /* NetworkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1702C554B40004560E3 /* NetworkHandler.swift */; };
+		6FC0A1722C554B40004560E3 /* NetworkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1702C554B40004560E3 /* NetworkHandler.swift */; };
+		6FC0A1742C554C9E004560E3 /* TMProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1732C554C9E004560E3 /* TMProfileDTO.swift */; };
+		6FC0A1752C554C9E004560E3 /* TMProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1732C554C9E004560E3 /* TMProfileDTO.swift */; };
+		6FC0A1772C554CC6004560E3 /* TMProfileVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1762C554CC6004560E3 /* TMProfileVO.swift */; };
+		6FC0A1782C554CC6004560E3 /* TMProfileVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1762C554CC6004560E3 /* TMProfileVO.swift */; };
 		6FF9B7742C4F896800FC0CB2 /* ShoakApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */; };
 		6FF9B7782C4F896A00FC0CB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */; };
 		6FF9B77B2C4F896A00FC0CB2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B77A2C4F896A00FC0CB2 /* Preview Assets.xcassets */; };
@@ -42,9 +48,9 @@
 		6FF9B79A2C50E6CB00FC0CB2 /* UserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7992C50E6CB00FC0CB2 /* UserUseCase.swift */; };
 		6FF9B79C2C50E6D700FC0CB2 /* SampleUseCase2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B79B2C50E6D700FC0CB2 /* SampleUseCase2.swift */; };
 		6FF9B79E2C50E6DE00FC0CB2 /* AccountUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B79D2C50E6DE00FC0CB2 /* AccountUseCase.swift */; };
-		6FF9B7A22C50E88300FC0CB2 /* TMProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A12C50E88300FC0CB2 /* TMProfileDTO.swift */; };
+		6FF9B7A22C50E88300FC0CB2 /* TMFriendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A12C50E88300FC0CB2 /* TMFriendDTO.swift */; };
 		6FF9B7A42C50E8A000FC0CB2 /* TMMemberID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A32C50E8A000FC0CB2 /* TMMemberID.swift */; };
-		6FF9B7A62C50E90100FC0CB2 /* TMProfileVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A52C50E90100FC0CB2 /* TMProfileVO.swift */; };
+		6FF9B7A62C50E90100FC0CB2 /* TMFriendVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A52C50E90100FC0CB2 /* TMFriendVO.swift */; };
 		6FF9B7A82C50ECD200FC0CB2 /* CaseIterable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A72C50ECD200FC0CB2 /* CaseIterable+.swift */; };
 		6FF9B7AA2C512C9F00FC0CB2 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A92C512C9F00FC0CB2 /* Errors.swift */; };
 		6FF9B7AC2C51322900FC0CB2 /* StartShoakProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7AB2C51322900FC0CB2 /* StartShoakProcess.swift */; };
@@ -58,9 +64,9 @@
 		6FF9B7C42C52378C00FC0CB2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF9B7C32C52378C00FC0CB2 /* Preview Assets.xcassets */; };
 		6FF9B7C72C52378C00FC0CB2 /* ShoakWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 6FF9B7BA2C52378B00FC0CB2 /* ShoakWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6FF9B7CC2C52380200FC0CB2 /* ShoakDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7B02C51F82B00FC0CB2 /* ShoakDataManager.swift */; };
-		6FF9B7CE2C52390200FC0CB2 /* TMProfileVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A52C50E90100FC0CB2 /* TMProfileVO.swift */; };
+		6FF9B7CE2C52390200FC0CB2 /* TMFriendVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A52C50E90100FC0CB2 /* TMFriendVO.swift */; };
 		6FF9B7CF2C52399500FC0CB2 /* TMMemberID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A32C50E8A000FC0CB2 /* TMMemberID.swift */; };
-		6FF9B7D02C52399E00FC0CB2 /* TMProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A12C50E88300FC0CB2 /* TMProfileDTO.swift */; };
+		6FF9B7D02C52399E00FC0CB2 /* TMFriendDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A12C50E88300FC0CB2 /* TMFriendDTO.swift */; };
 		6FF9B7D12C5239A400FC0CB2 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A92C512C9F00FC0CB2 /* Errors.swift */; };
 		6FF9B7D22C5239B300FC0CB2 /* AccountUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B79D2C50E6DE00FC0CB2 /* AccountUseCase.swift */; };
 		6FF9B7D52C5243C700FC0CB2 /* CaseIterable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9B7A72C50ECD200FC0CB2 /* CaseIterable+.swift */; };
@@ -121,6 +127,9 @@
 		6FC0A15B2C552DF6004560E3 /* ShoakWatch-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "ShoakWatch-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
 		6FC0A1602C552E3F004560E3 /* ShoakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShoakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FC0A1692C552FAC004560E3 /* UserUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUseCaseTests.swift; sourceTree = "<group>"; };
+		6FC0A1702C554B40004560E3 /* NetworkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkHandler.swift; sourceTree = "<group>"; };
+		6FC0A1732C554C9E004560E3 /* TMProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMProfileDTO.swift; sourceTree = "<group>"; };
+		6FC0A1762C554CC6004560E3 /* TMProfileVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMProfileVO.swift; sourceTree = "<group>"; };
 		6FF9B7702C4F896800FC0CB2 /* Shoak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Shoak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FF9B7732C4F896800FC0CB2 /* ShoakApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakApp.swift; sourceTree = "<group>"; };
 		6FF9B7772C4F896A00FC0CB2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -131,9 +140,9 @@
 		6FF9B7992C50E6CB00FC0CB2 /* UserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUseCase.swift; sourceTree = "<group>"; };
 		6FF9B79B2C50E6D700FC0CB2 /* SampleUseCase2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUseCase2.swift; sourceTree = "<group>"; };
 		6FF9B79D2C50E6DE00FC0CB2 /* AccountUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountUseCase.swift; sourceTree = "<group>"; };
-		6FF9B7A12C50E88300FC0CB2 /* TMProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMProfileDTO.swift; sourceTree = "<group>"; };
+		6FF9B7A12C50E88300FC0CB2 /* TMFriendDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMFriendDTO.swift; sourceTree = "<group>"; };
 		6FF9B7A32C50E8A000FC0CB2 /* TMMemberID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMMemberID.swift; sourceTree = "<group>"; };
-		6FF9B7A52C50E90100FC0CB2 /* TMProfileVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMProfileVO.swift; sourceTree = "<group>"; };
+		6FF9B7A52C50E90100FC0CB2 /* TMFriendVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMFriendVO.swift; sourceTree = "<group>"; };
 		6FF9B7A72C50ECD200FC0CB2 /* CaseIterable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+.swift"; sourceTree = "<group>"; };
 		6FF9B7A92C512C9F00FC0CB2 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		6FF9B7AB2C51322900FC0CB2 /* StartShoakProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartShoakProcess.swift; sourceTree = "<group>"; };
@@ -215,6 +224,7 @@
 				6FC0A1402C551B20004560E3 /* URLProvider.swift */,
 				6FC0A14D2C5523FF004560E3 /* DefaultAPIClient.swift */,
 				6FC0A1502C5524DE004560E3 /* NetworkError.swift */,
+				6FC0A1702C554B40004560E3 /* NetworkHandler.swift */,
 				6FC0A1492C55207C004560E3 /* Repository */,
 				6FC0A1352C551A3A004560E3 /* API */,
 			);
@@ -310,9 +320,11 @@
 			isa = PBXGroup;
 			children = (
 				6FF9B7A32C50E8A000FC0CB2 /* TMMemberID.swift */,
-				6FF9B7A12C50E88300FC0CB2 /* TMProfileDTO.swift */,
-				6FF9B7A52C50E90100FC0CB2 /* TMProfileVO.swift */,
+				6FF9B7A12C50E88300FC0CB2 /* TMFriendDTO.swift */,
+				6FF9B7A52C50E90100FC0CB2 /* TMFriendVO.swift */,
 				6FF9B7A92C512C9F00FC0CB2 /* Errors.swift */,
+				6FC0A1732C554C9E004560E3 /* TMProfileDTO.swift */,
+				6FC0A1762C554CC6004560E3 /* TMProfileVO.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -619,6 +631,8 @@
 				6FC0A1542C5526EE004560E3 /* MoyaProvider+.swift in Sources */,
 				6FC0A1572C552BAE004560E3 /* TargetType+.swift in Sources */,
 				6FF9B7AA2C512C9F00FC0CB2 /* Errors.swift in Sources */,
+				6FC0A1742C554C9E004560E3 /* TMProfileDTO.swift in Sources */,
+				6FC0A1712C554B40004560E3 /* NetworkHandler.swift in Sources */,
 				6FC0A1412C551B20004560E3 /* URLProvider.swift in Sources */,
 				6FF9B7AE2C51340000FC0CB2 /* SendShoakUseCase.swift in Sources */,
 				6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */,
@@ -626,10 +640,11 @@
 				1E2939852C51F2A200B321DC /* AppleSignInButton.swift in Sources */,
 				1E2939802C51E00D00B321DC /* AppleLoginView.swift in Sources */,
 				6FF9B7A42C50E8A000FC0CB2 /* TMMemberID.swift in Sources */,
-				6FF9B7A22C50E88300FC0CB2 /* TMProfileDTO.swift in Sources */,
-				6FF9B7A62C50E90100FC0CB2 /* TMProfileVO.swift in Sources */,
+				6FF9B7A22C50E88300FC0CB2 /* TMFriendDTO.swift in Sources */,
+				6FF9B7A62C50E90100FC0CB2 /* TMFriendVO.swift in Sources */,
 				6FF9B7B52C52211A00FC0CB2 /* RootView.swift in Sources */,
 				6FF9B79C2C50E6D700FC0CB2 /* SampleUseCase2.swift in Sources */,
+				6FC0A1772C554CC6004560E3 /* TMProfileVO.swift in Sources */,
 				6FF9B7742C4F896800FC0CB2 /* ShoakApp.swift in Sources */,
 				6FF9B7B32C51F84600FC0CB2 /* NavigationManager.swift in Sources */,
 				6FF9B7AC2C51322900FC0CB2 /* StartShoakProcess.swift in Sources */,
@@ -650,9 +665,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6FF9B7D02C52399E00FC0CB2 /* TMProfileDTO.swift in Sources */,
+				6FF9B7D02C52399E00FC0CB2 /* TMFriendDTO.swift in Sources */,
+				6FC0A1722C554B40004560E3 /* NetworkHandler.swift in Sources */,
 				6FC0A14F2C5523FF004560E3 /* DefaultAPIClient.swift in Sources */,
-				6FF9B7CE2C52390200FC0CB2 /* TMProfileVO.swift in Sources */,
+				6FF9B7CE2C52390200FC0CB2 /* TMFriendVO.swift in Sources */,
 				6FC0A1422C551B20004560E3 /* URLProvider.swift in Sources */,
 				6FC0A1582C552BAE004560E3 /* TargetType+.swift in Sources */,
 				6FF9B7CF2C52399500FC0CB2 /* TMMemberID.swift in Sources */,
@@ -664,9 +680,11 @@
 				6FF9B7D22C5239B300FC0CB2 /* AccountUseCase.swift in Sources */,
 				6FF9B7BF2C52378B00FC0CB2 /* ContentView.swift in Sources */,
 				6FF9B7DB2C5244B400FC0CB2 /* StartShoakProcess.swift in Sources */,
+				6FC0A1752C554C9E004560E3 /* TMProfileDTO.swift in Sources */,
 				6FF9B7D72C5243DC00FC0CB2 /* WatchFriendListView.swift in Sources */,
 				6FF9B7DA2C52441700FC0CB2 /* WatchSettingView.swift in Sources */,
 				6FF9B7BD2C52378B00FC0CB2 /* ShoakWatchApp.swift in Sources */,
+				6FC0A1782C554CC6004560E3 /* TMProfileVO.swift in Sources */,
 				6FF9B7DC2C5246A000FC0CB2 /* NavigationManager.swift in Sources */,
 				6FC0A1522C5524DE004560E3 /* NetworkError.swift in Sources */,
 				6FC0A14C2C5520BA004560E3 /* UserRepository.swift in Sources */,

--- a/Shoak.xcodeproj/xcshareddata/xcschemes/Shoak.xcscheme
+++ b/Shoak.xcodeproj/xcshareddata/xcschemes/Shoak.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FF9B76F2C4F896800FC0CB2"
+               BuildableName = "Shoak.app"
+               BlueprintName = "Shoak"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FC0A15F2C552E3F004560E3"
+               BuildableName = "ShoakTests.xctest"
+               BlueprintName = "ShoakTests"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FF9B76F2C4F896800FC0CB2"
+            BuildableName = "Shoak.app"
+            BlueprintName = "Shoak"
+            ReferencedContainer = "container:Shoak.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FF9B76F2C4F896800FC0CB2"
+            BuildableName = "Shoak.app"
+            BlueprintName = "Shoak"
+            ReferencedContainer = "container:Shoak.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shoak.xcodeproj/xcshareddata/xcschemes/ShoakTests.xcscheme
+++ b/Shoak.xcodeproj/xcshareddata/xcschemes/ShoakTests.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FC0A15F2C552E3F004560E3"
+               BuildableName = "ShoakTests.xctest"
+               BlueprintName = "ShoakTests"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shoak.xcodeproj/xcshareddata/xcschemes/ShoakWatch Watch App.xcscheme
+++ b/Shoak.xcodeproj/xcshareddata/xcschemes/ShoakWatch Watch App.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FF9B7B92C52378B00FC0CB2"
+               BuildableName = "ShoakWatch Watch App.app"
+               BlueprintName = "ShoakWatch Watch App"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FF9B76F2C4F896800FC0CB2"
+               BuildableName = "Shoak.app"
+               BlueprintName = "Shoak"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6FC0A15F2C552E3F004560E3"
+               BuildableName = "ShoakTests.xctest"
+               BlueprintName = "ShoakTests"
+               ReferencedContainer = "container:Shoak.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FF9B7B92C52378B00FC0CB2"
+            BuildableName = "ShoakWatch Watch App.app"
+            BlueprintName = "ShoakWatch Watch App"
+            ReferencedContainer = "container:Shoak.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6FF9B7B92C52378B00FC0CB2"
+            BuildableName = "ShoakWatch Watch App.app"
+            BlueprintName = "ShoakWatch Watch App"
+            ReferencedContainer = "container:Shoak.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Shoak/Actors/CommonActor/UseCases/AccountUseCase.swift
+++ b/Shoak/Actors/CommonActor/UseCases/AccountUseCase.swift
@@ -5,7 +5,7 @@ final class AccountUseCase {
     }
 
     func getMyMemberID() -> TMMemberID? {
-        return "My Member ID"
+        return 12323423442
     }
 }
 

--- a/Shoak/Actors/ShoakActor/UseCases/UserUseCase.swift
+++ b/Shoak/Actors/ShoakActor/UseCases/UserUseCase.swift
@@ -7,12 +7,18 @@ final class UserUseCase {
         self.userRepository = userRepository
     }
 
-    func getProfile(id: TMMemberID) -> Result<TMProfileVO, Errors> {
-        let serverData: TMProfileDTO = .mockData // 서버 통신 후 가져온 DTO
-        return .success(toVO(serverData)) // VO를 리턴
+    func getProfile() async -> Result<TMProfileVO, NetworkError> {
+        let result = await userRepository.getProfile()
+        switch result {
+        case .success(let dto):
+            let vo = toVO(dto)
+            return .success(vo)
+        case .failure(let failure):
+            return .failure(failure)
+        }
     }
 
-    func getFriends() async -> Result<[TMProfileVO], NetworkError> {
+    func getFriends() async -> Result<[TMFriendVO], NetworkError> {
         let result = await userRepository.getFriends()
         switch result {
         case .success(let dto):
@@ -26,11 +32,15 @@ final class UserUseCase {
 
 // MARK: - Translater
 extension UserUseCase {
-    private func toVO(_ dto: TMProfileDTO) -> TMProfileVO {
-        TMProfileVO(
+    private func toVO(_ dto: TMFriendDTO) -> TMFriendVO {
+        TMFriendVO(
             memberID: dto.id,
             imageURLString: dto.imageURL,
             name: dto.name
         )
+    }
+
+    private func toVO(_ dto: TMProfileDTO) -> TMProfileVO {
+        TMProfileVO(name: dto.name, imageURL: dto.imageURL)
     }
 }

--- a/Shoak/Actors/ShoakActor/UseCases/UserUseCase.swift
+++ b/Shoak/Actors/ShoakActor/UseCases/UserUseCase.swift
@@ -1,20 +1,36 @@
 import Foundation
 
 final class UserUseCase {
+    let userRepository: UserRepository
+
+    init(userRepository: UserRepository) {
+        self.userRepository = userRepository
+    }
+
     func getProfile(id: TMMemberID) -> Result<TMProfileVO, Errors> {
         let serverData: TMProfileDTO = .mockData // 서버 통신 후 가져온 DTO
         return .success(toVO(serverData)) // VO를 리턴
     }
 
-    func getFriends(id: TMMemberID) -> Result<[TMProfileVO], Errors> {
-        return .success(.mockData)
+    func getFriends() async -> Result<[TMProfileVO], NetworkError> {
+        let result = await userRepository.getFriends()
+        switch result {
+        case .success(let dto):
+            let vo = dto.map(toVO)
+            return .success(vo)
+        case .failure(let failure):
+            return .failure(failure)
+        }
     }
-
 }
 
 // MARK: - Translater
 extension UserUseCase {
     private func toVO(_ dto: TMProfileDTO) -> TMProfileVO {
-        return TMProfileVO.mockData
+        TMProfileVO(
+            memberID: dto.id,
+            imageURLString: dto.imageURL,
+            name: dto.name
+        )
     }
 }

--- a/Shoak/Actors/ShoakActor/View/FriendListView.swift
+++ b/Shoak/Actors/ShoakActor/View/FriendListView.swift
@@ -10,6 +10,9 @@ struct FriendListView: View {
             List(shoakDataManager.friends, id: \.memberID) { member in
                 Text("member name : \(member.name)")
             }
+            .refreshable {
+                shoakDataManager.refreshFriends()
+            }
 
             Button("Go to Setting") {
                 navigationManager.setView(to: .settings)

--- a/Shoak/Common/ShoakDataManager.swift
+++ b/Shoak/Common/ShoakDataManager.swift
@@ -11,9 +11,31 @@ import Foundation
 class ShoakDataManager: @unchecked Sendable {
     static let shared = ShoakDataManager()
 
-    let friends: [TMProfileVO]
+    private let userUseCase: UserUseCase
+
+    var friends: [TMProfileVO]
 
     private init() {
         self.friends = .mockData
+        let apiClient = DefaultAPIClient()
+        let userRepository = UserRepository(apiClient: apiClient)
+        self.userUseCase = UserUseCase(userRepository: userRepository)
+        refreshFriends()
+    }
+
+    public func refreshFriends() {
+        Task {
+            await getFriends()
+        }
+    }
+
+    public func getFriends() async {
+        let result = await userUseCase.getFriends()
+        switch result {
+        case .success(let success):
+            self.friends = success
+        case .failure(let failure):
+            print("fail! : \(failure)")
+        }
     }
 }

--- a/Shoak/Common/ShoakDataManager.swift
+++ b/Shoak/Common/ShoakDataManager.swift
@@ -13,7 +13,7 @@ class ShoakDataManager: @unchecked Sendable {
 
     private let userUseCase: UserUseCase
 
-    var friends: [TMProfileVO]
+    var friends: [TMFriendVO]
 
     private init() {
         self.friends = .mockData

--- a/Shoak/Entity/TMFriendDTO.swift
+++ b/Shoak/Entity/TMFriendDTO.swift
@@ -1,0 +1,29 @@
+//
+//  TMFriendDTO.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/24/24.
+//
+
+import Foundation
+
+struct TMFriendDTO: Codable {
+    var id: TMMemberID
+    var imageURL: String?
+    var name: String
+}
+
+extension TMFriendDTO {
+    static var mockData: TMFriendDTO {
+        TMFriendDTO(id: 12314123, imageURL: "https://picsum.photos/200/300", name: "TestName")
+    }
+}
+
+extension Array where Element == TMFriendDTO {
+    static var testData: [TMFriendDTO] {
+        [
+            TMFriendDTO(id: 2, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
+            TMFriendDTO(id: 3, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
+        ]
+    }
+}

--- a/Shoak/Entity/TMFriendVO.swift
+++ b/Shoak/Entity/TMFriendVO.swift
@@ -1,0 +1,42 @@
+//
+//  TMFriendVO.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/24/24.
+//
+
+import SwiftUI
+
+struct TMFriendVO: Equatable {
+    var memberID: TMMemberID
+    var imageURLString: String?
+    var name: String
+}
+
+extension TMFriendVO {
+    static var mockData: TMFriendVO {
+        TMFriendVO(memberID: 123123, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO")
+    }
+    static var mockData2: TMFriendVO {
+        TMFriendVO(memberID: 234234, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO 2")
+    }
+}
+
+extension Array where Element == TMFriendVO {
+    static var testData: [TMFriendVO] {
+        [
+            TMFriendVO(memberID: 2, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
+            TMFriendVO(memberID: 3, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
+        ]
+    }
+}
+
+
+extension Array where Element == TMFriendVO {
+    static var mockData: [Element] {
+        [
+            .mockData,
+            .mockData2
+        ]
+    }
+}

--- a/Shoak/Entity/TMMemberID.swift
+++ b/Shoak/Entity/TMMemberID.swift
@@ -7,4 +7,4 @@
 
 import Foundation
 
-typealias TMMemberID = String
+typealias TMMemberID = Int64

--- a/Shoak/Entity/TMProfileDTO.swift
+++ b/Shoak/Entity/TMProfileDTO.swift
@@ -2,28 +2,12 @@
 //  TMProfileDTO.swift
 //  Shoak
 //
-//  Created by 정종인 on 7/24/24.
+//  Created by 정종인 on 7/28/24.
 //
 
 import Foundation
 
 struct TMProfileDTO: Codable {
-    var id: TMMemberID
-    var imageURL: String?
     var name: String
-}
-
-extension TMProfileDTO {
-    static var mockData: TMProfileDTO {
-        TMProfileDTO(id: 12314123, imageURL: "https://picsum.photos/200/300", name: "TestName")
-    }
-}
-
-extension Array where Element == TMProfileDTO {
-    static var testData: [TMProfileDTO] {
-        [
-            TMProfileDTO(id: 2, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
-            TMProfileDTO(id: 3, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
-        ]
-    }
+    var imageURL: String?
 }

--- a/Shoak/Entity/TMProfileDTO.swift
+++ b/Shoak/Entity/TMProfileDTO.swift
@@ -7,14 +7,23 @@
 
 import Foundation
 
-struct TMProfileDTO {
-    var memberID: TMMemberID
-    var imageURLString: String?
+struct TMProfileDTO: Codable {
+    var id: TMMemberID
+    var imageURL: String?
     var name: String
 }
 
 extension TMProfileDTO {
     static var mockData: TMProfileDTO {
-        TMProfileDTO(memberID: "TestData", imageURLString: "https://picsum.photos/200/300", name: "TestName")
+        TMProfileDTO(id: 12314123, imageURL: "https://picsum.photos/200/300", name: "TestName")
+    }
+}
+
+extension Array where Element == TMProfileDTO {
+    static var testData: [TMProfileDTO] {
+        [
+            TMProfileDTO(id: 2, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
+            TMProfileDTO(id: 3, imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
+        ]
     }
 }

--- a/Shoak/Entity/TMProfileVO.swift
+++ b/Shoak/Entity/TMProfileVO.swift
@@ -2,41 +2,18 @@
 //  TMProfileVO.swift
 //  Shoak
 //
-//  Created by 정종인 on 7/24/24.
+//  Created by 정종인 on 7/28/24.
 //
 
-import SwiftUI
+import Foundation
 
-struct TMProfileVO: Equatable {
-    var memberID: TMMemberID
-    var imageURLString: String?
+struct TMProfileVO: Codable, Equatable {
     var name: String
+    var imageURL: String?
 }
 
 extension TMProfileVO {
-    static var mockData: TMProfileVO {
-        TMProfileVO(memberID: 123123, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO")
-    }
-    static var mockData2: TMProfileVO {
-        TMProfileVO(memberID: 234234, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO 2")
-    }
-}
-
-extension Array where Element == TMProfileVO {
-    static var testData: [TMProfileVO] {
-        [
-            TMProfileVO(memberID: 2, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
-            TMProfileVO(memberID: 3, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
-        ]
-    }
-}
-
-
-extension Array where Element == TMProfileVO {
-    static var mockData: [Element] {
-        [
-            .mockData,
-            .mockData2
-        ]
+    static var testData: TMProfileVO {
+        TMProfileVO(name: "이빈치", imageURL: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/a7b899ae-528e-4e37-a6f1-e9ac08ab50c9vinci.jpeg")
     }
 }

--- a/Shoak/Entity/TMProfileVO.swift
+++ b/Shoak/Entity/TMProfileVO.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct TMProfileVO {
+struct TMProfileVO: Equatable {
     var memberID: TMMemberID
     var imageURLString: String?
     var name: String
@@ -15,12 +15,22 @@ struct TMProfileVO {
 
 extension TMProfileVO {
     static var mockData: TMProfileVO {
-        TMProfileVO(memberID: "TestData from VO", imageURLString: "https://picsum.photos/200/200", name: "TestName from VO")
+        TMProfileVO(memberID: 123123, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO")
     }
     static var mockData2: TMProfileVO {
-        TMProfileVO(memberID: "TestData from VO 2", imageURLString: "https://picsum.photos/200/200", name: "TestName from VO 2")
+        TMProfileVO(memberID: 234234, imageURLString: "https://picsum.photos/200/200", name: "TestName from VO 2")
     }
 }
+
+extension Array where Element == TMProfileVO {
+    static var testData: [TMProfileVO] {
+        [
+            TMProfileVO(memberID: 2, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg", name: "백쿠미Test"),
+            TMProfileVO(memberID: 3, imageURLString: "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png", name: "정모수Test")
+        ]
+    }
+}
+
 
 extension Array where Element == TMProfileVO {
     static var mockData: [Element] {

--- a/Shoak/Info.plist
+++ b/Shoak/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/Shoak/Network/API/UserAPI.swift
+++ b/Shoak/Network/API/UserAPI.swift
@@ -1,0 +1,62 @@
+//
+//  UserAPI.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+import Moya
+
+enum UserAPI {
+    case getFriends
+}
+
+extension UserAPI: NeedAuthTargetType {
+    var baseURL: URL {
+        ShoakURLProvider().provide(version: .none)
+    }
+
+    var path: String {
+        switch self {
+        case .getFriends:
+            "/api/friend"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getFriends:
+            return .get
+        }
+    }
+
+    var sampleData: Data {
+        switch self {
+        case .getFriends:
+            return Data(
+                """
+                [
+                    {
+                        "id": 2,
+                        "name": "백쿠미Test",
+                        "imageURL": "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/kumi.jpeg"
+                    },
+                    {
+                        "id": 3,
+                        "name": "정모수Test",
+                        "imageURL": "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png"
+                    }
+                ]
+                """.utf8
+            )
+        }
+    }
+
+    var task: Task {
+        switch self {
+        case .getFriends:
+            return .requestPlain
+        }
+    }
+}

--- a/Shoak/Network/API/UserAPI.swift
+++ b/Shoak/Network/API/UserAPI.swift
@@ -9,6 +9,7 @@ import Foundation
 import Moya
 
 enum UserAPI {
+    case getProfile
     case getFriends
 }
 
@@ -19,6 +20,8 @@ extension UserAPI: NeedAuthTargetType {
 
     var path: String {
         switch self {
+        case .getProfile:
+            "/api/profile"
         case .getFriends:
             "/api/friend"
         }
@@ -26,13 +29,22 @@ extension UserAPI: NeedAuthTargetType {
 
     var method: Moya.Method {
         switch self {
-        case .getFriends:
+        case .getProfile, .getFriends:
             return .get
         }
     }
 
     var sampleData: Data {
         switch self {
+        case .getProfile:
+            return Data(
+                """
+                {
+                    "name": "이빈치",
+                    "imageURL": "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/a7b899ae-528e-4e37-a6f1-e9ac08ab50c9vinci.jpeg"
+                }
+                """.utf8
+            )
         case .getFriends:
             return Data(
                 """
@@ -55,7 +67,7 @@ extension UserAPI: NeedAuthTargetType {
 
     var task: Task {
         switch self {
-        case .getFriends:
+        case .getProfile, .getFriends:
             return .requestPlain
         }
     }

--- a/Shoak/Network/DefaultAPIClient.swift
+++ b/Shoak/Network/DefaultAPIClient.swift
@@ -1,0 +1,56 @@
+//
+//  APIClient.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+import Moya
+
+public protocol APIClient {
+    func resolve<Target: TargetType>(for target: Target.Type) -> MoyaProvider<Target>
+}
+
+final public class DefaultAPIClient: APIClient {
+    public func resolve<Target: TargetType>(for target: Target.Type) -> MoyaProvider<Target> {
+        return createProvider(for: target)
+    }
+}
+
+extension DefaultAPIClient {
+    private func createProvider<Target: TargetType>(for target: Target.Type) -> MoyaProvider<Target> {
+        let request = createRequest(for: target)
+        return MoyaProvider<Target>(requestClosure: request, plugins: []) // TODO: Logger 추가하기
+    }
+
+    private func createRequest<Target: TargetType>(for target: Target.Type) -> MoyaProvider<Target>.RequestClosure {
+        let requestClosure = { [weak self] (endpoint: Endpoint, done: @escaping MoyaProvider.RequestResultClosure) in
+            guard let request = try? endpoint.urlRequest() else {
+                done(.failure(.requestMapping(endpoint.url)))
+                return
+            }
+
+            done(.success(request))
+
+            // TODO: Token Logic 추가
+        }
+
+        return requestClosure
+    }
+}
+
+public final class TestAPIClient: APIClient {
+    public func resolve<Target: TargetType>(for target: Target.Type) -> MoyaProvider<Target> {
+        let customEndpointClosure = { (target: Target) -> Endpoint in
+            Endpoint(
+                url: URL(target: target).absoluteString,
+                sampleResponseClosure: { .networkResponse(200, target.sampleData) },
+                method: .get,
+                task: target.task,
+                httpHeaderFields: target.headers
+            )
+        }
+        return MoyaProvider<Target>(endpointClosure: customEndpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+    }
+}

--- a/Shoak/Network/NetworkError.swift
+++ b/Shoak/Network/NetworkError.swift
@@ -1,0 +1,44 @@
+//
+//  NetworkError.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+
+public enum NetworkError: Error, LocalizedError {
+    case requestError(ErrorResponse)
+    case decodeError
+    case pathError
+    case networkFail
+    case other(String)
+    case unknown
+}
+
+extension NetworkError {
+    public var errorDescription: String {
+        switch self {
+        case .requestError(let errorResponse):
+            "Request Error: \(errorResponse.message)"
+        case .decodeError:
+            "Decode Error"
+        case .pathError:
+            "Path Error"
+        case .networkFail:
+            "Network Fail"
+        case .other(let string):
+            "Other : \(string)"
+        case .unknown:
+            "Unknown Error"
+        }
+    }
+}
+
+public struct ErrorResponse: Error, Decodable {
+    public let timestamp: String
+    public let status: Int
+    public let error: String
+    public let message: String
+    public let path: String
+}

--- a/Shoak/Network/NetworkHandler.swift
+++ b/Shoak/Network/NetworkHandler.swift
@@ -1,0 +1,30 @@
+//
+//  NetworkHandler.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/28/24.
+//
+
+import Foundation
+import Moya
+
+public final class NetworkHandler {
+    public static func requestDecoded<T: Decodable>(by response: Response) -> Result<T, NetworkError> {
+        let decoder = JSONDecoder()
+
+        switch response.statusCode {
+        case 200..<300:
+            guard let decodedData = try? decoder.decode(T.self, from: response.data) else {
+                return .failure(.decodeError)
+            }
+            return .success(decodedData)
+        case 300..<500:
+            guard let errorResponse = try? decoder.decode(ErrorResponse.self, from: response.data) else {
+                return .failure(.pathError)
+            }
+            return .failure(.requestError(errorResponse))
+        default:
+            return .failure(.networkFail)
+        }
+    }
+}

--- a/Shoak/Network/Repository/UserRepository.swift
+++ b/Shoak/Network/Repository/UserRepository.swift
@@ -15,8 +15,8 @@ final class UserRepository {
         self.provider = apiClient.resolve(for: UserAPI.self)
     }
 
-    func getFriends() async -> Result<[TMProfileDTO], NetworkError> {
-        let response = await provider.request(.getFriends)
+    func getProfile() async -> Result<TMProfileDTO, NetworkError> {
+        let response = await provider.request(.getProfile)
         switch response {
         case .success(let success):
             return NetworkHandler.requestDecoded(by: success)
@@ -24,25 +24,14 @@ final class UserRepository {
             return .failure(.other(failure.localizedDescription))
         }
     }
-}
 
-public final class NetworkHandler {
-    public static func requestDecoded<T: Decodable>(by response: Response) -> Result<T, NetworkError> {
-        let decoder = JSONDecoder()
-
-        switch response.statusCode {
-        case 200..<300:
-            guard let decodedData = try? decoder.decode(T.self, from: response.data) else {
-                return .failure(.decodeError)
-            }
-            return .success(decodedData)
-        case 300..<500:
-            guard let errorResponse = try? decoder.decode(ErrorResponse.self, from: response.data) else {
-                return .failure(.pathError)
-            }
-            return .failure(.requestError(errorResponse))
-        default:
-            return .failure(.networkFail)
+    func getFriends() async -> Result<[TMFriendDTO], NetworkError> {
+        let response = await provider.request(.getFriends)
+        switch response {
+        case .success(let success):
+            return NetworkHandler.requestDecoded(by: success)
+        case .failure(let failure):
+            return .failure(.other(failure.localizedDescription))
         }
     }
 }

--- a/Shoak/Network/Repository/UserRepository.swift
+++ b/Shoak/Network/Repository/UserRepository.swift
@@ -1,0 +1,48 @@
+//
+//  UserRepository.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+import Moya
+
+final class UserRepository {
+    let provider: MoyaProvider<UserAPI>
+
+    init(apiClient: APIClient) {
+        self.provider = apiClient.resolve(for: UserAPI.self)
+    }
+
+    func getFriends() async -> Result<[TMProfileDTO], NetworkError> {
+        let response = await provider.request(.getFriends)
+        switch response {
+        case .success(let success):
+            return NetworkHandler.requestDecoded(by: success)
+        case .failure(let failure):
+            return .failure(.other(failure.localizedDescription))
+        }
+    }
+}
+
+public final class NetworkHandler {
+    public static func requestDecoded<T: Decodable>(by response: Response) -> Result<T, NetworkError> {
+        let decoder = JSONDecoder()
+
+        switch response.statusCode {
+        case 200..<300:
+            guard let decodedData = try? decoder.decode(T.self, from: response.data) else {
+                return .failure(.decodeError)
+            }
+            return .success(decodedData)
+        case 300..<500:
+            guard let errorResponse = try? decoder.decode(ErrorResponse.self, from: response.data) else {
+                return .failure(.pathError)
+            }
+            return .failure(.requestError(errorResponse))
+        default:
+            return .failure(.networkFail)
+        }
+    }
+}

--- a/Shoak/Network/URLProvider.swift
+++ b/Shoak/Network/URLProvider.swift
@@ -1,0 +1,48 @@
+//
+//  URLProvider.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+
+public protocol URLProvider {
+    func provide(version: URLVersion) -> URL
+}
+
+public enum URLVersion: String {
+    case none = ""
+}
+
+public struct ShoakURLProvider: URLProvider {
+    private var baseURL: String {
+        Secrets.baseURL
+    }
+
+    private var testURL: String {
+        baseURL
+    }
+
+    public func provide(version: URLVersion) -> URL {
+        #if TEST
+        URL(string: testURL + version.rawValue)!
+        #else
+        URL(string: baseURL + version.rawValue)!
+        #endif
+    }
+}
+
+private struct Secrets {
+    static var baseURL: String {
+        guard let url = Bundle.main.url(forResource: "Secret", withExtension: "plist") else {
+            return ""
+        }
+
+        guard let dictionary = try? NSDictionary(contentsOf: url, error: ()), let baseURL = dictionary["baseURL"] as? String else {
+            return ""
+        }
+
+        return baseURL
+    }
+}

--- a/Shoak/Network/URLProvider.swift
+++ b/Shoak/Network/URLProvider.swift
@@ -26,6 +26,7 @@ public struct ShoakURLProvider: URLProvider {
 
     public func provide(version: URLVersion) -> URL {
         #if TEST
+        // TODO: 아직 scheme과 custom flag 설정 안해둠. configuration은 해둠.
         URL(string: testURL + version.rawValue)!
         #else
         URL(string: baseURL + version.rawValue)!

--- a/Shoak/Utility/MoyaProvider+.swift
+++ b/Shoak/Utility/MoyaProvider+.swift
@@ -1,0 +1,18 @@
+//
+//  MoyaProvider+.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Moya
+
+extension MoyaProvider {
+    func request(_ target: Target) async -> Result<Response, MoyaError> {
+        await withCheckedContinuation { continuation in
+            self.request(target) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+}

--- a/Shoak/Utility/TargetType+.swift
+++ b/Shoak/Utility/TargetType+.swift
@@ -1,0 +1,21 @@
+//
+//  TargetType+.swift
+//  Shoak
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import Foundation
+import Moya
+
+public protocol NeedAuthTargetType: TargetType {}
+
+extension NeedAuthTargetType {
+    public var headers: [String : String]? {
+        var headers = ["Content-Type": "application/json"]
+
+//        headers["Authorization"] = ""
+
+        return headers
+    }
+}

--- a/ShoakTests/UserUseCaseTests.swift
+++ b/ShoakTests/UserUseCaseTests.swift
@@ -27,7 +27,7 @@ final class UserUseCaseTests: XCTestCase {
         let result = await userUseCase.getFriends()
         switch result {
         case .success(let success):
-            XCTAssertEqual(success, [TMFriendVO].testData)
+            XCTAssert((success as Any) is [TMFriendVO])
         case .failure(let failure):
             XCTFail(failure.errorDescription)
         }
@@ -37,7 +37,7 @@ final class UserUseCaseTests: XCTestCase {
         let result = await userUseCase.getProfile()
         switch result {
         case .success(let success):
-            XCTAssertEqual(success, TMProfileVO.testData)
+            XCTAssert((success as Any) is TMProfileVO)
         case .failure(let failure):
             XCTFail(failure.errorDescription)
         }

--- a/ShoakTests/UserUseCaseTests.swift
+++ b/ShoakTests/UserUseCaseTests.swift
@@ -27,7 +27,17 @@ final class UserUseCaseTests: XCTestCase {
         let result = await userUseCase.getFriends()
         switch result {
         case .success(let success):
-            XCTAssertEqual(success, [TMProfileVO].testData)
+            XCTAssertEqual(success, [TMFriendVO].testData)
+        case .failure(let failure):
+            XCTFail(failure.errorDescription)
+        }
+    }
+
+    func test_프로필_불러오기() async throws {
+        let result = await userUseCase.getProfile()
+        switch result {
+        case .success(let success):
+            XCTAssertEqual(success, TMProfileVO.testData)
         case .failure(let failure):
             XCTFail(failure.errorDescription)
         }

--- a/ShoakTests/UserUseCaseTests.swift
+++ b/ShoakTests/UserUseCaseTests.swift
@@ -1,0 +1,43 @@
+//
+//  UserUseCaseTests.swift
+//  ShoakTests
+//
+//  Created by 정종인 on 7/27/24.
+//
+
+import XCTest
+@testable import Shoak
+
+final class UserUseCaseTests: XCTestCase {
+
+    var userUseCase: UserUseCase!
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        let apiClient = TestAPIClient()
+        let userRepository = UserRepository(apiClient: apiClient)
+        self.userUseCase = UserUseCase(userRepository: userRepository)
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func test_친구_불러오기() async throws {
+        let result = await userUseCase.getFriends()
+        switch result {
+        case .success(let success):
+            XCTAssertEqual(success, [TMProfileVO].testData)
+        case .failure(let failure):
+            XCTFail(failure.errorDescription)
+        }
+    }
+
+//    func testPerformanceExample() throws {
+//        // This is an example of a performance test case.
+//        self.measure {
+//            // Put the code you want to measure the time of here.
+//        }
+//    }
+
+}

--- a/ShoakWatch-Watch-App-Info.plist
+++ b/ShoakWatch-Watch-App-Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Moya를 활용한 서버 연결코드를 작성했습니다.
이를 테스트할 수 있는 테스트 코드도 작성했습니다.

아직 Token Logic을 판별하는 코드는 추가하지 않았습니다.
아직 통신마다 작동하는 Logger는 추가하지 않았습니다.
아직 서버 통신을 제대로 확인하지 않았습니다.

### 중요!!
이제부터 Secrets.plist 파일이 필요합니다.
서버 URL 등 민감한 정보가 있는 파일이며, 개인적으로 공유드리겠습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #15 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- MoyaProvider를 테스트환경과 일반환경에서 다르게 동작할 수 있도록 하였습니다. TestAPIClient와 DefaultAPIClient 코드를 참고해주세요.
- TEST Configuration은 추후 스테이징이 나눠질 때 스킴을 나눌 수 있도록 미리 설정해두었습니다. 필요 시 스킴 생성 후 커스텀플래그까지 설정하면 됩니다.
- 테스트코드는 현재는 UseCase만 테스트를 추가해두었습니다. setUpWithError() 함수에서 TestAPIClient를 DefaultAPIClient로 바꾸면 실제 서버와 통신하는 것으로 테스트 가능합니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://github.com/Moya/Moya


## 🔥 Test
<!-- Test -->
(뷰 츄가한 것이 없기 때문에 생략합니다)
