### PR TITLE
[#52] medium으로 되어있던 폰트 수정

### DIFF
--- a/Shoak/DesignSystem/Font/FontManager.swift
+++ b/Shoak/DesignSystem/Font/FontManager.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 extension Font {
-    static let iconButton: Font = .system(size: 32, weight: .medium)
+    static let iconButton: Font = .system(size: 32, weight: .bold)
     static let icon: Font = .system(size: 20, weight: .regular)
-    static let textPageTitle: Font = .system(size: 20, weight: .medium)
-    static let textListTitle: Font = .system(size: 20, weight: .medium)
+    static let textPageTitle: Font = .system(size: 20, weight: .bold)
+    static let textListTitle: Font = .system(size: 20, weight: .bold)
     static let textBody: Font = .system(size: 14, weight: .regular)
-    static let textButton: Font = .system(size: 14, weight: .medium)
-    static let textTitle: Font = .system(size: 20, weight: .medium)
+    static let textButton: Font = .system(size: 14, weight: .bold)
+    static let textTitle: Font = .system(size: 20, weight: .bold)
 }


### PR DESCRIPTION
## 📌 Summary
폰트 수정 했습니다.


## ✍️ Description
FontManager.swift파일에서 수정진행했습니다.

## 💡 PR Point

긁어서 새로 타자쳐서 넣었습니다.

## 📚 Reference 

SF pro상으론 apple SD gothic 의 Regular와 bold만 확인 가능합니다. 다들 조심!
<img width="310" alt="image" src="https://github.com/user-attachments/assets/843120b5-c543-41d6-9074-58182cb623ff">



## 🔥 Test
<!-- Test -->

