### PR TITLE
[Feat] Watch에서도 shoak 보내지게 설정

### DIFF
--- a/Shoak.xcodeproj/project.pbxproj
+++ b/Shoak.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		6FA442B02C591A1A00E3E69E /* TMUserCredentialVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA442AE2C591A1A00E3E69E /* TMUserCredentialVO.swift */; };
 		6FA442B22C59239E00E3E69E /* ShoakAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA442B12C59239E00E3E69E /* ShoakAppDelegate.swift */; };
 		6FA442B52C59DDA300E3E69E /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA442B42C59DDA300E3E69E /* BackButton.swift */; };
+		6FBEED432C5B5F1C00431B7F /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBEED422C5B5F1C00431B7F /* WatchConnectivityManager.swift */; };
+		6FBEED452C5B632700431B7F /* PhoneConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBEED442C5B632700431B7F /* PhoneConnectivityManager.swift */; };
 		6FC0A12A2C54C82B004560E3 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A1292C54C82B004560E3 /* LoginView.swift */; };
 		6FC0A12C2C54CA29004560E3 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */; };
 		6FC0A12E2C54CB11004560E3 /* AccountManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC0A12D2C54CB11004560E3 /* AccountManager.swift */; };
@@ -220,6 +222,8 @@
 		6FA442AE2C591A1A00E3E69E /* TMUserCredentialVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TMUserCredentialVO.swift; sourceTree = "<group>"; };
 		6FA442B12C59239E00E3E69E /* ShoakAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShoakAppDelegate.swift; sourceTree = "<group>"; };
 		6FA442B42C59DDA300E3E69E /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
+		6FBEED422C5B5F1C00431B7F /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		6FBEED442C5B632700431B7F /* PhoneConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneConnectivityManager.swift; sourceTree = "<group>"; };
 		6FC0A1292C54C82B004560E3 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		6FC0A12B2C54CA29004560E3 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		6FC0A12D2C54CB11004560E3 /* AccountManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManager.swift; sourceTree = "<group>"; };
@@ -595,6 +599,7 @@
 				6FF9B7B02C51F82B00FC0CB2 /* ShoakDataManager.swift */,
 				6FF9B7B22C51F84600FC0CB2 /* NavigationManager.swift */,
 				6FC0A12D2C54CB11004560E3 /* AccountManager.swift */,
+				6FBEED422C5B5F1C00431B7F /* WatchConnectivityManager.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -713,6 +718,7 @@
 				6FF9B7BC2C52378B00FC0CB2 /* ShoakWatchApp.swift */,
 				6FF9B7C02C52378C00FC0CB2 /* Assets.xcassets */,
 				6FF9B7C22C52378C00FC0CB2 /* Preview Content */,
+				6FBEED442C5B632700431B7F /* PhoneConnectivityManager.swift */,
 			);
 			path = "ShoakWatch Watch App";
 			sourceTree = "<group>";
@@ -1007,6 +1013,7 @@
 				1E21684F2C587223007463D0 /* InvitationUseCase.swift in Sources */,
 				6FC0A17E2C563A02004560E3 /* TokenStorage.swift in Sources */,
 				6FC0A1AC2C57DBBB004560E3 /* StoreTokenPlugin.swift in Sources */,
+				6FBEED432C5B5F1C00431B7F /* WatchConnectivityManager.swift in Sources */,
 				6FC0A17E2C563A02004560E3 /* TokenStorage.swift in Sources */,
 				1E2168382C5689BF007463D0 /* MessageComposeView.swift in Sources */,
 				6FF9B7B52C52211A00FC0CB2 /* RootView.swift in Sources */,
@@ -1086,12 +1093,12 @@
 				6FC0A1782C554CC6004560E3 /* TMProfileVO.swift in Sources */,
 				6FF9B7DC2C5246A000FC0CB2 /* NavigationManager.swift in Sources */,
 				6FC0A1522C5524DE004560E3 /* NetworkError.swift in Sources */,
+				6FBEED452C5B632700431B7F /* PhoneConnectivityManager.swift in Sources */,
 				6FC0A17F2C563A02004560E3 /* TokenStorage.swift in Sources */,
 				6FC0A14C2C5520BA004560E3 /* UserRepository.swift in Sources */,
 				6FC0A1A12C57C3D3004560E3 /* TMLoginOrSignUpDTO.swift in Sources */,
 				6FC0A19E2C57C13B004560E3 /* AuthAPI.swift in Sources */,
 				6FC0A1862C563C42004560E3 /* Keychain.swift in Sources */,
-				6FC0A1922C5696EA004560E3 /* TokenRefreshAPIService.swift in Sources */,
 				B8FF5C3B2C5A23BB00F043EB /* CircleImage.swift in Sources */,
 				B8FF5C392C59DE0000F043EB /* WatchNotificationController.swift in Sources */,
 				6FC0D50C2C59E62D005BD525 /* TMTokenRefreshRequestDTO.swift in Sources */,

--- a/Shoak/Common/WatchConnectivityManager.swift
+++ b/Shoak/Common/WatchConnectivityManager.swift
@@ -1,0 +1,61 @@
+//
+//  WatchConnectivityManager.swift
+//  Shoak
+//
+//  Created by 정종인 on 8/1/24.
+//
+
+import Foundation
+import WatchConnectivity
+
+@Observable
+final class WatchConnectivityManager: NSObject, WCSessionDelegate {
+    static let shared = WatchConnectivityManager()
+    @ObservationIgnored var session: WCSession
+
+    init(session: WCSession = .default) {
+        self.session = session
+        super.init()
+        self.session.delegate = self
+        session.activate()
+    }
+
+    /// sendUserInfo : 비동기적으로 데이터를 전송하며, 데이터가 전달된 순서대로 순차적으로 수신됩니다.
+//    func sendUserInfo(data: [String: Any]) {
+//        WCSession.default.transferUserInfo(data)
+//    }
+
+    /// 앱의 현재 상태를 나타내는 데이터를 전송합니다. 이 메서드는 단일 상태를 전송하며, 이전 상태는 새로운 상태로 덮어쓰여집니다.
+    /// Apple Watch가 연결되어 있지 않을 때 전송된 데이터는 나중에 연결되었을 때 수신됩니다. 하지만 여러 번 상태가 업데이트되면 가장 최근에 업데이트된 상태만 유효하며 이전 상태는 무시됩니다.
+//    func updateApplicationContext(data: [String: Any]) {
+//        do {
+//            try WCSession.default.updateApplicationContext(data)
+//            print("Update application context: \(data)")
+//        } catch {
+//            print("Failed to update application context: \(error.localizedDescription)")
+//        }
+//    }
+
+    // WCSessionDelegate Methods
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        // Handle activation state
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        // Handle session becoming inactive
+    }
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        // Handle session deactivation
+        WCSession.default.activate()
+    }
+
+    func sendMessage(data: [String: Any]) {
+        do {
+            print("send message : \(data)")
+            try self.session.updateApplicationContext(data)
+        } catch {
+            print("error! : \(error.localizedDescription)")
+        }
+    }
+}

--- a/Shoak/Network/Token/TokenManager.swift
+++ b/Shoak/Network/Token/TokenManager.swift
@@ -23,10 +23,6 @@ final public class TokenManager: @unchecked Sendable {
         // get할 때 keychain에서 가져오는 로직을 수행 함.
         self.accessToken = accessToken
         self.refreshToken = refreshToken
-        // TODO: 위에꺼로 다시 바꾸기
-//        self.accessToken = AccessToken("eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6ImFjY2VzcyIsInVzZXJuYW1lIjoiMTciLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzIyNDM0OTUwLCJleHAiOjE3MjUwMjY5NTB9.RmcsCvh39l2aHtNJVATklJYY7fAuyrdBC8FilAHi0DI")
-//
-//        self.refreshToken = RefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6InJlZnJlc2giLCJ1c2VybmFtZSI6IkRlZmF1bHQgTmFtZSIsInJvbGUiOiJST0xFX1VTRVIiLCJpYXQiOjE3MjI0MzQ5NTAsImV4cCI6MTcyNzYxODk1MH0.jmWUHPA6tK1IX3TvPIQrYdga_4IulOFDpGGZJJv0OdY")
     }
 
     /// URLRequest에 대해 토큰이 유효하다면 Access, Refresh 헤더에 Bearer 토큰 붙여주는 로직 (async/await 기반)
@@ -54,10 +50,21 @@ final public class TokenManager: @unchecked Sendable {
 public extension TokenManager {
     func save(_ accessToken: AccessToken) {
         self.accessToken = accessToken
+        print("save access Token : \(accessToken.token)")
+
+#if os(iOS)
+        let watchConnectivity = WatchConnectivityManager.shared
+        watchConnectivity.sendMessage(data: ["Access": accessToken.token as Any, "Refresh": refreshToken?.token as Any])
+#endif
     }
 
     func save(_ refreshToken: RefreshToken) {
         self.refreshToken = refreshToken
+        print("save refresh Token : \(refreshToken.token)")
+#if os(iOS)
+        let watchConnectivity = WatchConnectivityManager.shared
+        watchConnectivity.sendMessage(data: ["Access": accessToken?.token as Any, "Refresh": refreshToken.token as Any])
+#endif
     }
 
     func save(_ identityToken: IdentityToken) {

--- a/Shoak/ShoakApp.swift
+++ b/Shoak/ShoakApp.swift
@@ -15,6 +15,7 @@ struct ShoakApp: App {
     private var accountManager: AccountManager
     private let navigationManager: NavigationManager
     private var invitationManager: InvitationManager
+    private var watchConnectivityManager: WatchConnectivityManager
 
     init() {
         let shoakDataManager = ShoakDataManager.shared
@@ -29,6 +30,9 @@ struct ShoakApp: App {
         let invitationManager = InvitationManager.shared
         self.invitationManager = invitationManager
 
+        let watchConnectivityManager = WatchConnectivityManager.shared
+        self.watchConnectivityManager = watchConnectivityManager
+
         AppDependencyManager.shared.add(dependency: shoakDataManager)
         AppDependencyManager.shared.add(dependency: accountManager)
         AppDependencyManager.shared.add(dependency: navigationManager)
@@ -41,6 +45,7 @@ struct ShoakApp: App {
                 .environment(accountManager)
                 .environment(navigationManager)
                 .environment(invitationManager)
+                .environment(watchConnectivityManager)
         }
     }
 }

--- a/ShoakWatch Watch App/PhoneConnectivityManager.swift
+++ b/ShoakWatch Watch App/PhoneConnectivityManager.swift
@@ -1,0 +1,48 @@
+//
+//  PhoneConnectivityManager.swift
+//  ShoakWatch Watch App
+//
+//  Created by 정종인 on 8/1/24.
+//
+
+import Foundation
+import WatchConnectivity
+
+@Observable
+class PhoneConnectivityManager: NSObject, WCSessionDelegate {
+    static let shared = PhoneConnectivityManager()
+    @ObservationIgnored var session: WCSession
+    var message: String = "No message received"
+
+    private init(session: WCSession = .default) {
+        self.session = session
+        super.init()
+        self.session.delegate = self
+        session.activate()
+    }
+
+    // WCSessionDelegate Methods
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        // Handle activation state
+    }
+
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any] = [:]) {
+        DispatchQueue.main.async {
+            print("receive user info : \(userInfo)")
+            if let receivedMessage = userInfo["Access"] as? String {
+                self.message = receivedMessage
+            }
+        }
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        DispatchQueue.main.async {
+            print("receive user info : \(applicationContext)")
+            if let receivedAccessToken = applicationContext["Access"] as? String, let receivedRefreshToken = applicationContext["Refresh"] as? String {
+                self.message = receivedAccessToken
+                TokenManager().save(AccessToken(receivedAccessToken))
+                TokenManager().save(RefreshToken(receivedRefreshToken))
+            }
+        }
+    }
+}

--- a/ShoakWatch Watch App/ShoakWatchApp.swift
+++ b/ShoakWatch Watch App/ShoakWatchApp.swift
@@ -13,14 +13,15 @@ import UserNotifications
 struct ShoakWatch_Watch_AppApp: App {
     private var shoakDataManager: ShoakDataManager
     private let navigationManager: NavigationManager
+    private let phoneConnectivityManager: PhoneConnectivityManager
 
     init() {
         
         Task {
-                  let center = UNUserNotificationCenter.current()
-                  let options: UNAuthorizationOptions = [.alert, .sound, .badge]
-                  _ = try? await center.requestAuthorization(options: options)
-              }
+            let center = UNUserNotificationCenter.current()
+            let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+            _ = try? await center.requestAuthorization(options: options)
+        }
         
         let shoakDataManager = ShoakDataManager.shared
         self.shoakDataManager = shoakDataManager
@@ -28,16 +29,19 @@ struct ShoakWatch_Watch_AppApp: App {
         let navigationManager = NavigationManager()
         self.navigationManager = navigationManager
 
+        let phoneConnectivityManager = PhoneConnectivityManager.shared
+        self.phoneConnectivityManager = phoneConnectivityManager
+
         AppDependencyManager.shared.add(dependency: shoakDataManager)
         AppDependencyManager.shared.add(dependency: navigationManager)
     }
-    
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(shoakDataManager)
                 .environment(navigationManager)
+                .environment(phoneConnectivityManager)
         }
         WKNotificationScene(controller: WatchNotificationController.self, category: "몰라")
     }

--- a/ShoakWatch Watch App/View/ContentView.swift
+++ b/ShoakWatch Watch App/View/ContentView.swift
@@ -10,6 +10,7 @@ import UserNotifications
 
 struct ContentView: View {
     @Environment(NavigationManager.self) private var navigationManager
+    @Environment(PhoneConnectivityManager.self) private var phoneConnectivityManager
     var body: some View {
         navigationManager.view
             .task {

--- a/ShoakWatch Watch App/View/WatchFriendListView.swift
+++ b/ShoakWatch Watch App/View/WatchFriendListView.swift
@@ -25,6 +25,10 @@ struct WatchFriendListView: View {
                     tappedStates[member.memberID] = false
                 }
                 print("Selected member: \(member.name)")
+
+                Task {
+                    await shoakDataManager.sendShoak(to: member.memberID)
+                }
             }) {
                 HStack {
                     if tappedStates[member.memberID, default: false] {
@@ -50,13 +54,8 @@ struct WatchFriendListView: View {
                     .fill(tappedStates[member.memberID, default: false] ? Color.shoakGreen : Color.shoakYellow )
             )
         }
-        .refreshable {
-            Task {
-                await shoakDataManager.refreshFriends()
-            }
-        }
         .onAppear {
-            self.shoakDataManager.friends = .mockData
+            self.shoakDataManager.refreshFriends()
         }
     }
     


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Watch에서도 shoak 보내지게 설정

Watch Connectivity로 token 데이터를 watch로 보내기
watch 에서는 그 데이터를 받아서 keychain에 저장.
나중에 api 보낼 때 그 keychain의 데이터를 빼서 보내기


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #50


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

