### PR TITLE
[Fix] 쇽 버튼 로직 수정

### DIFF
--- a/Shoak/Actors/ShoakActor/View/FriendListView.swift
+++ b/Shoak/Actors/ShoakActor/View/FriendListView.swift
@@ -86,75 +86,76 @@ struct FriendListView: View {
         
         @State private var property: Properties = .default
         
-        init(friend: TMFriendVO, property: Properties = .default) {
-            self.friend = friend
-            self._property = State(initialValue: property)
-        }
-        
         var body: some View {
-            Button {
-                switch property {
-                case .default:
-                    self.property = .confirm
-                case .confirm:
-                    Task {
-                        let result = await shoakDataManager.sendShoak(to: friend.memberID)
-                        switch result {
-                        case .success:
-                            property = .complete
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                                property = .default
-                            }
-                        case .failure:
-                            property = .default
-                        }
-                    }
-                default:
-                    break
-                }
-            } label: {
-                HStack(spacing: 0) {
-                    if let imageURLString = friend.imageURLString,
-                       let imageURL = URL(string: imageURLString) {
-                        AsyncImage(url: imageURL) { image in
-                            image
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 80, height: 80)
-                                .clipShapeBorder(RoundedRectangle(cornerRadius: 30), Color.strokeGray, 1.0)
-                                .padding(.leading, 15)
-                        } placeholder: {
-                            ProgressView()
-                                .frame(width: 80, height: 80)
-                                .background(Color(red: 0.85, green: 0.85, blue: 0.85))
-                                .cornerRadius(30)
-                                .padding(.leading, 15)
-                        }
-                    } else {
-                        Image(.defaultProfile)
+            HStack(spacing: 0) {
+                if let imageURLString = friend.imageURLString,
+                   let imageURL = URL(string: imageURLString) {
+                    AsyncImage(url: imageURL) { image in
+                        image
                             .resizable()
+                            .aspectRatio(contentMode: .fill)
                             .frame(width: 80, height: 80)
                             .clipShapeBorder(RoundedRectangle(cornerRadius: 30), Color.strokeGray, 1.0)
                             .padding(.leading, 15)
+                    } placeholder: {
+                        ProgressView()
+                            .frame(width: 80, height: 80)
+                            .background(Color(red: 0.85, green: 0.85, blue: 0.85))
+                            .cornerRadius(30)
+                            .padding(.leading, 15)
                     }
-                    
-                    Text(friend.name)
-                        .font(.textTitle)
-                        .padding(.leading, 19)
-                    
-                    Spacer()
-                    
-                    property.accessoryView
-                        .frame(width: 100, height: 60)
-                        .padding(.trailing, 23)
+                } else {
+                    Image(.defaultProfile)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                        .clipShapeBorder(RoundedRectangle(cornerRadius: 30), Color.strokeGray, 1.0)
+                        .padding(.leading, 15)
                 }
-                .frame(minHeight: 110)
-                .background(property.backgroundColor)
+                
+                Text(friend.name)
+                    .font(.textTitle)
+                    .padding(.leading, 19)
+                
+                Spacer()
+                
+                property.accessoryView(onButtonTapped: {
+                    switch property {
+                    case .confirm:
+                        sendShoak()
+                    default:
+                        break
+                    }
+                })
+                .frame(width: 100, height: 60)
+                .padding(.trailing, 23)
             }
-            .transition(.identity)
-            .buttonStyle(.plain)
+            .frame(minHeight: 110)
+            .background(property.backgroundColor)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                if property == .default {
+                    property = .confirm
+                } else {
+                    property = .default
+                }
+            }
             .clipShapeBorder(RoundedRectangle(cornerRadius: 12), Color.strokeBlack, 1.0)
             .animation(.default, value: self.property)
+        }
+        
+        private func sendShoak() {
+            Task {
+                let result = await shoakDataManager.sendShoak(to: friend.memberID)
+                switch result {
+                case .success:
+                    property = .complete
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                        property = .default
+                    }
+                case .failure:
+                    property = .default
+                }
+            }
         }
         
         enum Properties {
@@ -166,26 +167,29 @@ struct FriendListView: View {
             var backgroundColor: Color {
                 switch self {
                 case .confirm:
-                    Color.shoakYellow
+                    return Color.shoakYellow
                 default:
-                    Color.shoakWhite
+                    return Color.shoakWhite
                 }
             }
             
             @ViewBuilder
-            var accessoryView: some View {
+            func accessoryView(onButtonTapped: @escaping () -> Void) -> some View {
                 switch self {
                 case .default:
                     Color.clear.contentShape(Rectangle())
                 case .confirm:
-                    Image(.shoakHandGestureIcon)
-                        .frame(width: 100, height: 51)
-                        .background(Color.shoakNavy)
-                        .cornerRadius(30)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 30)
-                                .strokeBorder(Color.strokeWhite, lineWidth: 1)
-                        )
+                    Button(action: onButtonTapped) {
+                        Image(.shoakHandGestureIcon)
+                            .frame(width: 100, height: 51)
+                            .background(Color.shoakNavy)
+                            .cornerRadius(30)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 30)
+                                    .strokeBorder(Color.strokeWhite, lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 case .complete:
                     Image(systemName: "checkmark.circle")
                         .resizable()


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 쇽 보내기 취소 가능하도록 수정 -> 노란색 상태에서 보내기 버튼 클릭했을 때 쇽 보내지고, 그 이외 부분에서는 취소됨


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #58 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 보내기 버튼 UI는 피그마에서 수정된 게 최종인지 모르겠어서 아직 안 바꿨습니다!

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
https://github.com/user-attachments/assets/e2f40d6a-6079-479f-b5f6-0edd491defca
