### PR TITLE
[Fix] 이름 변경 시 버튼 disable 로직 추가

### DIFF
--- a/Shoak/Actors/CommonActor/View/SettingView.swift
+++ b/Shoak/Actors/CommonActor/View/SettingView.swift
@@ -246,6 +246,7 @@ struct MyProfileView: View {
                     }
                 }
             }
+            .disabled(name.count > 8 || name.isEmpty)
         } message: {
             Text("수정할 이름을 입력해주세요 (최대 8글자)")
         }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
이름 변경 시 입력 란이 비어있거나 8글자가 넘어가면 버튼을 disable하는 로직을 추가했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #103 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
![IMG_2891](https://github.com/user-attachments/assets/c3b89369-6339-4cfa-aab8-a10374a41040)

![IMG_2892](https://github.com/user-attachments/assets/34ee0f0d-896a-4ab5-af2f-e70523b83957)

![IMG_2893](https://github.com/user-attachments/assets/e4f1ec74-243d-49fa-846c-79c81e1682bf)
