### PR TITLE
[Fix] 딥링크 처리 과정에서 이전에 처리한 딥링크는 다시 인식하지 않도록 변경, 로그인 시 디바이스 토큰 갱신 기다리기, 토큰 갱신 실패 시 401이 떠도 로그아웃 하도록 변경

### DIFF
--- a/Shoak/Actors/ShoakActor/View/FriendListView.swift
+++ b/Shoak/Actors/ShoakActor/View/FriendListView.swift
@@ -156,7 +156,10 @@ struct FriendListView: View {
                         .padding(.leading, 19)
 
                     Spacer()
-
+                }
+                .frame(minHeight: 110)
+                .background(property.backgroundColor)
+                .overlay(alignment: .trailing) {
                     property.accessoryView(onButtonTapped: {
                         switch property {
                         case .confirm:
@@ -168,8 +171,6 @@ struct FriendListView: View {
                     .frame(width: 100, height: 60)
                     .padding(.trailing, 23)
                 }
-                .frame(minHeight: 110)
-                .background(property.backgroundColor)
                 .contentShape(Rectangle())
                 .clipShapeBorder(RoundedRectangle(cornerRadius: 12), Color.strokeBlack, 1.0)
             }

--- a/Shoak/Actors/ShoakActor/View/FriendListView.swift
+++ b/Shoak/Actors/ShoakActor/View/FriendListView.swift
@@ -5,7 +5,9 @@ import StoreKit
 struct FriendListView: View {
     @Environment(ShoakDataManager.self) private var shoakDataManager
     @Environment(NavigationManager.self) private var navigationManager
+#if APPCLIP
     @State private var showAppStoreOverlay = false
+#endif
     var body: some View {
         @Bindable var navigationManager = navigationManager
         VStack {
@@ -14,14 +16,18 @@ struct FriendListView: View {
         }
         .onAppear {
             shoakDataManager.refreshFriends()
+#if APPCLIP
             showAppStoreOverlay = true
+#endif
         }
         .sheet(item: $navigationManager.invitation) { invitation in
             AcceptInvitationView()
         }
+#if APPCLIP
         .appStoreOverlay(isPresented: $showAppStoreOverlay) {
             SKOverlay.AppClipConfiguration(position: .bottom)
         }
+#endif
     }
     
     struct TopButtons: View {

--- a/Shoak/Network/API/UserAPI.swift
+++ b/Shoak/Network/API/UserAPI.swift
@@ -84,7 +84,7 @@ extension UserAPI: NeedAccessTokenTargetType {
                     },
                     {
                         "id": 3,
-                        "name": "정모수Test",
+                        "name": "여덟글자꽉채워서",
                         "imageURL": "https://ada-mc3.s3.ap-northeast-2.amazonaws.com/profile/mosu.png"
                     }
                 ]

--- a/Shoak/Network/MoyaPlugins/AddTokenPlugin.swift
+++ b/Shoak/Network/MoyaPlugins/AddTokenPlugin.swift
@@ -28,13 +28,13 @@ struct AddTokenPlugin: PluginType {
         if needAccessToken(request),
            let accessToken = tokenRepository.getAccessToken() {
             print("\n🐈🐈🐈🐈 헤더에 Access Token 추가 완료!")
-            request.setValue("Bearer \(accessToken.token)1", forHTTPHeaderField: "Access")
+            request.setValue("Bearer \(accessToken.token)", forHTTPHeaderField: "Access")
         }
 
         if needRefreshToken(request),
            let refreshToken = tokenRepository.getRefreshToken() {
             print("\n🐈🐈🐈🐈 헤더에 Refresh Token 추가 완료!")
-            request.setValue("Bearer \(refreshToken.token)1", forHTTPHeaderField: "Refresh")
+            request.setValue("Bearer \(refreshToken.token)", forHTTPHeaderField: "Refresh")
         }
 
         if needIdentityToken(request),

--- a/Shoak/Network/MoyaPlugins/AddTokenPlugin.swift
+++ b/Shoak/Network/MoyaPlugins/AddTokenPlugin.swift
@@ -28,13 +28,13 @@ struct AddTokenPlugin: PluginType {
         if needAccessToken(request),
            let accessToken = tokenRepository.getAccessToken() {
             print("\n🐈🐈🐈🐈 헤더에 Access Token 추가 완료!")
-            request.setValue("Bearer \(accessToken.token)", forHTTPHeaderField: "Access")
+            request.setValue("Bearer \(accessToken.token)1", forHTTPHeaderField: "Access")
         }
 
         if needRefreshToken(request),
            let refreshToken = tokenRepository.getRefreshToken() {
             print("\n🐈🐈🐈🐈 헤더에 Refresh Token 추가 완료!")
-            request.setValue("Bearer \(refreshToken.token)", forHTTPHeaderField: "Refresh")
+            request.setValue("Bearer \(refreshToken.token)1", forHTTPHeaderField: "Refresh")
         }
 
         if needIdentityToken(request),

--- a/Shoak/Network/MoyaPlugins/LogoutPlugin.swift
+++ b/Shoak/Network/MoyaPlugins/LogoutPlugin.swift
@@ -18,7 +18,7 @@ struct LogoutPlugin: PluginType {
     }
     func didReceive(_ result: Result<Response, MoyaError>, target: any TargetType) {
         if case .failure(let failure) = result {
-            if failure.response?.statusCode == 403 {
+            if failure.response?.statusCode == 401 || failure.response?.statusCode == 403 {
                 tokenRepository.deleteAllTokens()
 #if os(iOS)
                 UIApplication.shared.unregisterForRemoteNotifications()

--- a/Shoak/ShoakApp.swift
+++ b/Shoak/ShoakApp.swift
@@ -17,6 +17,8 @@ struct ShoakApp: App {
     private var invitationManager: InvitationManager
     private var watchConnectivityManager: WatchConnectivityManager
 
+    @State private var lastProcessedURL: URL = URL(string: "https://example.com")!
+
     init() {
         let tokenRepository = KeychainTokenRepository()
         let tokenRefreshRepository = DefaultTokenRefreshRepository(tokenRepository: tokenRepository)
@@ -78,6 +80,11 @@ struct ShoakApp: App {
     private func handleDeepLink(_ navigationManager: NavigationManager, url: URL) {
         print("Deep link URL: \(url.absoluteString)")
 
+        guard lastProcessedURL != url else {
+            print("건너뜀!")
+            return
+        }
+
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               let memberID = components.queryItems?.first(where: { $0.name == "memberID" })?.value,
               let memberIDToInt64 = Int64(memberID, radix: 10) else {
@@ -85,5 +92,6 @@ struct ShoakApp: App {
         }
 
         navigationManager.invitation = memberIDToInt64
+        lastProcessedURL = url
     }
 }

--- a/ShoakClip/ShoakClipApp.swift
+++ b/ShoakClip/ShoakClipApp.swift
@@ -16,6 +16,8 @@ struct ShoakClipApp: App {
     private var invitationManager: InvitationManager
     private var watchConnectivityManager: WatchConnectivityManager
 
+    @State private var lastProcessedURL: URL = URL(string: "https://example.com")!
+
     init() {
         let tokenRepository = KeychainTokenRepository()
         let tokenRefreshRepository = DefaultTokenRefreshRepository(tokenRepository: tokenRepository)
@@ -60,11 +62,12 @@ struct ShoakClipApp: App {
                 .environment(invitationManager)
                 .environment(watchConnectivityManager)
                 .onOpenURL { url in
+                    print("url : \(url)")
                     handleDeepLink(navigationManager, url: url)
                 }
                 .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                    guard let incomingURL = userActivity.webpageURL
-                    else {
+                    print("continue user activity : \(userActivity)")
+                    guard let incomingURL = userActivity.webpageURL else {
                         return
                     }
 
@@ -76,6 +79,11 @@ struct ShoakClipApp: App {
     private func handleDeepLink(_ navigationManager: NavigationManager, url: URL) {
         print("Deep link URL: \(url.absoluteString)")
 
+        guard lastProcessedURL != url else {
+            print("건너뜀!")
+            return
+        }
+
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               let memberID = components.queryItems?.first(where: { $0.name == "memberID" })?.value,
               let memberIDToInt64 = Int64(memberID, radix: 10) else {
@@ -83,5 +91,6 @@ struct ShoakClipApp: App {
         }
 
         navigationManager.invitation = memberIDToInt64
+        lastProcessedURL = url
     }
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
딥링크 처리 과정에서 이전에 처리한 딥링크는 다시 인식하지 않도록 변경했습니다.
앱을 나갔다가 들어오면 친구 수락 페이지가 계속 뜨는 것이 이제 없어질 것입니다.

로그인 시 디바이스 토큰이 갱신되는 것을 다 기다리고 로그인 api를 호출합니다

토큰 갱신 실패 시 401이 오는 것을 확인해서 401이 떠도 로그아웃 되도록 수정했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #107 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

